### PR TITLE
SLING-9847 Fixed code to let GraphQL query execution errors pass on to result

### DIFF
--- a/src/main/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutor.java
+++ b/src/main/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutor.java
@@ -145,8 +145,8 @@ public class DefaultQueryExecutor implements QueryExecutor {
                         errors.append("location=").append(location.getLine()).append(",").append(location.getColumn()).append(";");
                     }
                 }
-                throw new SlingGraphQLException(String.format("Query failed for Resource %s: schema=%s, query=%s%nErrors:%n%s",
-                        queryResource.getPath(), schemaDef, query, errors.toString()));
+                LOGGER.error("Query failed for Resource {}: schema={}, query={} Errors:{}",
+                        queryResource.getPath(), schemaDef, query, errors.toString());
             }
             LOGGER.debug("ExecutionResult.isDataPresent={}", result.isDataPresent());
             return result.toSpecification();

--- a/src/main/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutor.java
+++ b/src/main/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutor.java
@@ -146,7 +146,7 @@ public class DefaultQueryExecutor implements QueryExecutor {
                     }
                 }
                 LOGGER.error("Query failed for Resource {}: schema={}, query={} Errors:{}",
-                        queryResource.getPath(), schemaDef, query, errors.toString());
+                        queryResource.getPath(), schemaDef, query, errors);
             }
             LOGGER.debug("ExecutionResult.isDataPresent={}", result.isDataPresent());
             return result.toSpecification();

--- a/src/test/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutorTest.java
+++ b/src/test/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutorTest.java
@@ -111,6 +111,15 @@ public class DefaultQueryExecutorTest extends ResourceQueryTestBase {
     }
 
     @Test
+    public void queryValidationErrorResponseTest() throws Exception {
+        final String json = queryJSON("{ currentResource_NON_EXISTENT { nullValue } }");
+        assertThat(json, hasJsonPath("$.errors[0].message"));
+        assertThat(json, hasJsonPath("$.errors[0].locations"));
+        assertThat(json, hasJsonPath("$.errors[0].extensions"));
+        assertThat(json, hasJsonPath("$.errors[0].extensions.classification", is("ValidationError")));
+    }
+
+    @Test
     public void dataFetcherFailureTest() {
         try {
             final String stmt = "{ currentResource { failure } }";


### PR DESCRIPTION
Problem description and the proposed solution is here: https://issues.apache.org/jira/browse/SLING-9847
Fixing it as following:
- Do not throw exception, when execution of a GraphQL query returns "errors" in its response, rather only log it.
- Added a unit test  to verify inclusion of `errors` object in JSON response.