### PR TITLE
Sling 9877 - GraphQL error response for schema/other related errors

### DIFF
--- a/src/main/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutor.java
+++ b/src/main/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutor.java
@@ -161,7 +161,7 @@ public class DefaultQueryExecutor implements QueryExecutor {
             LOGGER.debug("ExecutionResult.isDataPresent={}", result.isDataPresent());
             return result.toSpecification();
         } catch (Exception e) {
-            String message = String.format("Query failed for Resource %s: query=%s", queryResource.getPath(), cleanLog.sanitize(query));
+            final String message = String.format("Query failed for Resource %s: query=%s", queryResource.getPath(), cleanLog.sanitize(query));
             LOGGER.error(String.format("%s, schema=%s", message, schemaDef), e);
             return SlingGraphQLErrorHelper.toSpecification(message, e);
         }

--- a/src/main/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutor.java
+++ b/src/main/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutor.java
@@ -35,6 +35,7 @@ import org.apache.sling.graphql.api.SlingTypeResolver;
 import org.apache.sling.graphql.core.logging.Sanitizer;
 import org.apache.sling.graphql.core.scalars.SlingScalarsProvider;
 import org.apache.sling.graphql.core.schema.RankedSchemaProviders;
+import org.apache.sling.graphql.core.util.SlingGraphQLErrorHelper;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.osgi.service.component.annotations.Component;
@@ -156,15 +157,15 @@ public class DefaultQueryExecutor implements QueryExecutor {
                     LOGGER.error("Query failed for Resource {}: query={} Errors:{}, schema={}",
                         queryResource.getPath(), cleanLog.sanitize(query), errors, schemaDef);
                 }
-
             }
             LOGGER.debug("ExecutionResult.isDataPresent={}", result.isDataPresent());
             return result.toSpecification();
         } catch (SlingGraphQLException e) {
             throw e;
         } catch (Exception e) {
-            throw new SlingGraphQLException(
-                    String.format("Query failed for Resource %s: schema=%s, query=%s", queryResource.getPath(), schemaDef, query), e);
+            String message = String.format("Query failed for Resource %s: query=%s", queryResource.getPath(), cleanLog.sanitize(query));
+            LOGGER.error(String.format("%s, schema=%s", message, schemaDef), e);
+            return SlingGraphQLErrorHelper.toSpecificaton(message, e);
         }
     }
 

--- a/src/main/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutor.java
+++ b/src/main/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutor.java
@@ -160,10 +160,6 @@ public class DefaultQueryExecutor implements QueryExecutor {
             }
             LOGGER.debug("ExecutionResult.isDataPresent={}", result.isDataPresent());
             return result.toSpecification();
-        } catch (SlingGraphQLException e) {
-            String message = String.format("Query failed for Resource %s: query=%s", queryResource.getPath(), cleanLog.sanitize(query));
-            LOGGER.error(String.format("%s, schema=%s", message, schemaDef), e);
-            return SlingGraphQLErrorHelper.toSpecification(message, e);
         } catch (Exception e) {
             String message = String.format("Query failed for Resource %s: query=%s", queryResource.getPath(), cleanLog.sanitize(query));
             LOGGER.error(String.format("%s, schema=%s", message, schemaDef), e);

--- a/src/main/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutor.java
+++ b/src/main/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutor.java
@@ -161,11 +161,13 @@ public class DefaultQueryExecutor implements QueryExecutor {
             LOGGER.debug("ExecutionResult.isDataPresent={}", result.isDataPresent());
             return result.toSpecification();
         } catch (SlingGraphQLException e) {
-            throw e;
+            String message = String.format("Query failed for Resource %s: query=%s", queryResource.getPath(), cleanLog.sanitize(query));
+            LOGGER.error(String.format("%s, schema=%s", message, schemaDef), e);
+            return SlingGraphQLErrorHelper.toSpecification(message, e);
         } catch (Exception e) {
             String message = String.format("Query failed for Resource %s: query=%s", queryResource.getPath(), cleanLog.sanitize(query));
             LOGGER.error(String.format("%s, schema=%s", message, schemaDef), e);
-            return SlingGraphQLErrorHelper.toSpecificaton(message, e);
+            return SlingGraphQLErrorHelper.toSpecification(message, e);
         }
     }
 

--- a/src/main/java/org/apache/sling/graphql/core/util/SlingGraphQLErrorHelper.java
+++ b/src/main/java/org/apache/sling/graphql/core/util/SlingGraphQLErrorHelper.java
@@ -18,10 +18,10 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package org.apache.sling.graphql.core.util;
 
-import graphql.GraphQLError;
-
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 public class SlingGraphQLErrorHelper {
     

--- a/src/main/java/org/apache/sling/graphql/core/util/SlingGraphQLErrorHelper.java
+++ b/src/main/java/org/apache/sling/graphql/core/util/SlingGraphQLErrorHelper.java
@@ -32,6 +32,9 @@ public class SlingGraphQLErrorHelper {
     public static final String GRAPHQL_ERROR_CAUSE = "cause";
     public static final String GRAPHQL_ERROR_CAUSE_STACKTRACE = "stacktrace";
     public static final String GRAPHQL_ERROR_ERRORS = "errors";
+    
+    private SlingGraphQLErrorHelper(){
+    }
 
     /**
      * Structures the given error information into a {@code Map} following GraphQL error specification.
@@ -39,16 +42,16 @@ public class SlingGraphQLErrorHelper {
      * @param e exception.
      * @return a map containing error detail.
      */
-    public static Map<String, Object> toSpecification(String customMessage, Exception e) {
-        Map<String, Object> additionalExceptionInfo = new LinkedHashMap<>();
+    public static Map<String, Object> toSpecification(final String customMessage, final Exception e) {
+        final Map<String, Object> additionalExceptionInfo = new LinkedHashMap<>();
         additionalExceptionInfo.put(GRAPHQL_ERROR_MESSAGE, e.getMessage());
 
-        Map<String, Object> extensionsMap = new LinkedHashMap<>();
+        final Map<String, Object> extensionsMap = new LinkedHashMap<>();
         extensionsMap.put(GRAPHQL_ERROR_DETAIL, customMessage);
         extensionsMap.put(GRAPHQL_ERROR_EXCEPTION, e.getClass().getName());
         if (e.getCause() != null) {
             extensionsMap.put(GRAPHQL_ERROR_CAUSE, e.getCause().toString());
-            List<String> stacktrace =  new ArrayList<>();
+            final List<String> stacktrace =  new ArrayList<>();
             
             //keep top 10 (max) stacktrace entries
             for (int i=0; i<e.getCause().getStackTrace().length && i<10; i++) {
@@ -58,10 +61,10 @@ public class SlingGraphQLErrorHelper {
         }
         additionalExceptionInfo.put(GRAPHQL_ERROR_EXTENSIONS, extensionsMap);
 
-        List<Map<String, Object>> errorList = new ArrayList<>();
+        final List<Map<String, Object>> errorList = new ArrayList<>();
         errorList.add(0, additionalExceptionInfo);
 
-        Map<String, Object> result = new LinkedHashMap<>();
+        final Map<String, Object> result = new LinkedHashMap<>();
         result.put(GRAPHQL_ERROR_ERRORS, errorList );
 
         return result;

--- a/src/main/java/org/apache/sling/graphql/core/util/SlingGraphQLErrorHelper.java
+++ b/src/main/java/org/apache/sling/graphql/core/util/SlingGraphQLErrorHelper.java
@@ -39,13 +39,13 @@ public class SlingGraphQLErrorHelper {
      * @param e exception.
      * @return a map containing error detail.
      */
-    public static Map<String, Object> toSpecificaton(String customMessage, Exception e) {
+    public static Map<String, Object> toSpecification(String customMessage, Exception e) {
         Map<String, Object> additionalExceptionInfo = new LinkedHashMap<>();
         additionalExceptionInfo.put(GRAPHQL_ERROR_MESSAGE, e.getMessage());
 
         Map<String, Object> extensionsMap = new LinkedHashMap<>();
         extensionsMap.put(GRAPHQL_ERROR_DETAIL, customMessage);
-        extensionsMap.put(GRAPHQL_ERROR_EXCEPTION, e.getClass().getSimpleName());
+        extensionsMap.put(GRAPHQL_ERROR_EXCEPTION, e.getClass().getName());
         if (e.getCause() != null) {
             extensionsMap.put(GRAPHQL_ERROR_CAUSE, e.getCause().toString());
             List<String> stacktrace =  new ArrayList<>();

--- a/src/main/java/org/apache/sling/graphql/core/util/SlingGraphQLErrorHelper.java
+++ b/src/main/java/org/apache/sling/graphql/core/util/SlingGraphQLErrorHelper.java
@@ -51,12 +51,8 @@ public class SlingGraphQLErrorHelper {
             List<String> stacktrace =  new ArrayList<>();
             
             //keep top 10 (max) stacktrace entries
-            int i = 0;
-            for (StackTraceElement stackTraceElement : e.getCause().getStackTrace()) {
+            for (int i=0; i<e.getCause().getStackTrace().length && i<10; i++) {
                 stacktrace.add(e.getCause().getStackTrace()[i].toString());
-                if (++i > 9) {
-                    break;
-                }
             }
             extensionsMap.put(GRAPHQL_ERROR_CAUSE_STACKTRACE, stacktrace);
         }

--- a/src/main/java/org/apache/sling/graphql/core/util/SlingGraphQLErrorHelper.java
+++ b/src/main/java/org/apache/sling/graphql/core/util/SlingGraphQLErrorHelper.java
@@ -1,0 +1,73 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Licensed to the Apache Software Foundation (ASF) under one
+ ~ or more contributor license agreements.  See the NOTICE file
+ ~ distributed with this work for additional information
+ ~ regarding copyright ownership.  The ASF licenses this file
+ ~ to you under the Apache License, Version 2.0 (the
+ ~ "License"); you may not use this file except in compliance
+ ~ with the License.  You may obtain a copy of the License at
+ ~
+ ~   http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package org.apache.sling.graphql.core.util;
+
+import graphql.GraphQLError;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class SlingGraphQLErrorHelper {
+    
+    public static final String GRAPHQL_ERROR_EXTENSIONS = "extensions";
+    public static final String GRAPHQL_ERROR_MESSAGE = "message";
+    public static final String GRAPHQL_ERROR_DETAIL = "detail";
+    public static final String GRAPHQL_ERROR_EXCEPTION = "exception";
+    public static final String GRAPHQL_ERROR_CAUSE = "cause";
+    public static final String GRAPHQL_ERROR_CAUSE_STACKTRACE = "stacktrace";
+    public static final String GRAPHQL_ERROR_ERRORS = "errors";
+
+    /**
+     * Structures the given error information into a {@code Map} following GraphQL error specification.
+     * @param customMessage custom message to be included in the response. 
+     * @param e exception.
+     * @return a map containing error detail.
+     */
+    public static Map<String, Object> toSpecificaton(String customMessage, Exception e) {
+        Map<String, Object> additionalExceptionInfo = new LinkedHashMap<>();
+        additionalExceptionInfo.put(GRAPHQL_ERROR_MESSAGE, e.getMessage());
+
+        Map<String, Object> extensionsMap = new LinkedHashMap<>();
+        extensionsMap.put(GRAPHQL_ERROR_DETAIL, customMessage);
+        extensionsMap.put(GRAPHQL_ERROR_EXCEPTION, e.getClass().getSimpleName());
+        if (e.getCause() != null) {
+            extensionsMap.put(GRAPHQL_ERROR_CAUSE, e.getCause().toString());
+            List<String> stacktrace =  new ArrayList<>();
+            
+            //keep top 10 (max) stacktrace entries
+            int i = 0;
+            for (StackTraceElement stackTraceElement : e.getCause().getStackTrace()) {
+                stacktrace.add(e.getCause().getStackTrace()[i].toString());
+                if (++i > 9) {
+                    break;
+                }
+            }
+            extensionsMap.put(GRAPHQL_ERROR_CAUSE_STACKTRACE, stacktrace);
+        }
+        additionalExceptionInfo.put(GRAPHQL_ERROR_EXTENSIONS, extensionsMap);
+
+        List<Map<String, Object>> errorList = new ArrayList<>();
+        errorList.add(0, additionalExceptionInfo);
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put(GRAPHQL_ERROR_ERRORS, errorList );
+
+        return result;
+    }
+}

--- a/src/test/java/org/apache/sling/graphql/core/engine/CustomScalarsTest.java
+++ b/src/test/java/org/apache/sling/graphql/core/engine/CustomScalarsTest.java
@@ -56,7 +56,7 @@ public class CustomScalarsTest extends ResourceQueryTestBase {
     public void urlSyntaxError() throws Exception {
         final String url = "This is not an URL!";
         final String query = String.format("{ address (url: \"%s\") { url hostname } }", url);
-        String json = queryJSON(query);
+        final String json = queryJSON(query);
         assertThat(json, hasJsonPath("$.errors[0].extensions.cause", is(ScalarConversionException.class.getCanonicalName() + ": " + URLScalarConverter.class.getSimpleName() + ":Invalid URL:" + url)));
     }
 }

--- a/src/test/java/org/apache/sling/graphql/core/engine/CustomScalarsTest.java
+++ b/src/test/java/org/apache/sling/graphql/core/engine/CustomScalarsTest.java
@@ -20,6 +20,7 @@ package org.apache.sling.graphql.core.engine;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.hamcrest.Matchers.equalTo;
@@ -52,15 +53,10 @@ public class CustomScalarsTest extends ResourceQueryTestBase {
     }
 
     @Test
-    public void urlSyntaxError() {
+    public void urlSyntaxError() throws Exception {
         final String url = "This is not an URL!";
         final String query = String.format("{ address (url: \"%s\") { url hostname } }", url);
-        try {
-            queryJSON(query);
-            fail("Expecting a parsing exception for URL=" + url);
-        } catch(Exception e) {
-            TestUtil.assertNestedException(e, ScalarConversionException.class, URLScalarConverter.class.getSimpleName() + ":Invalid URL:" + url);
-        }
+        String json = queryJSON(query);
+        assertThat(json, hasJsonPath("$.errors[0].extensions.cause", is(ScalarConversionException.class.getCanonicalName() + ": " + URLScalarConverter.class.getSimpleName() + ":Invalid URL:" + url)));
     }
-
 }

--- a/src/test/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutorTest.java
+++ b/src/test/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutorTest.java
@@ -158,15 +158,14 @@ public class DefaultQueryExecutorTest extends ResourceQueryTestBase {
                 Integer.MAX_VALUE);
         final ServiceRegistration<?> reg = TestUtil.registerSlingDataFetcher(context.bundleContext(), "missingSlash", new EchoDataFetcher(42));
         try {
-            queryJSON("{ currentResource { missingSlash } }", new String[] {});
-            fail("Expected query to fail");
-        } catch(Exception e) {
-            TestUtil.assertNestedException(e, SlingGraphQLException.class, "Invalid fetcher name missingSlash");
+            String json = queryJSON("{ currentResource { missingSlash } }", new String[] {});
+            assertThat(json, hasJsonPath("$.errors[0].message", containsString("Invalid fetcher name missingSlash")));
+            assertThat(json, hasJsonPath("$.errors[0].extensions.exception", is(SlingGraphQLException.class.getName())));
         } finally {
             reg.unregister();
         }
     }
-
+    
     @Test
     public void invalidTypeResolverNamesTest() {
         context.registerService(SchemaProvider.class, new MockSchemaProvider("failing-type-resolver-schema"), Constants.SERVICE_RANKING,
@@ -174,10 +173,9 @@ public class DefaultQueryExecutorTest extends ResourceQueryTestBase {
         final ServiceRegistration<?> reg = TestUtil.registerSlingTypeResolver(context.bundleContext(), "missingSlash",
                 new DummyTypeResolver());
         try {
-            queryJSON("{ currentResource { missingSlash } }", new String[] {});
-            fail("Expected query to fail");
-        } catch(Exception e) {
-            TestUtil.assertNestedException(e, SlingGraphQLException.class, "Invalid type resolver name missingSlash");
+            String json = queryJSON("{ currentResource { missingSlash } }", new String[] {});
+            assertThat(json, hasJsonPath("$.errors[0].message", containsString("Invalid type resolver name missingSlash")));
+            assertThat(json, hasJsonPath("$.errors[0].extensions.exception", is(SlingGraphQLException.class.getName())));
         } finally {
             reg.unregister();
         }

--- a/src/test/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutorTest.java
+++ b/src/test/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutorTest.java
@@ -143,7 +143,7 @@ public class DefaultQueryExecutorTest extends ResourceQueryTestBase {
     }
 
     @Test
-    public void schemaSelectorsTest() throws Exception {
+    public void schemaSelectorsTest(){
         final String [] selectors = { "selected", "foryou" };
         final String json = queryJSON("{ currentResource { path fortyTwo } }", selectors);
 
@@ -158,7 +158,7 @@ public class DefaultQueryExecutorTest extends ResourceQueryTestBase {
                 Integer.MAX_VALUE);
         final ServiceRegistration<?> reg = TestUtil.registerSlingDataFetcher(context.bundleContext(), "missingSlash", new EchoDataFetcher(42));
         try {
-            String json = queryJSON("{ currentResource { missingSlash } }", new String[] {});
+            final String json = queryJSON("{ currentResource { missingSlash } }", new String[] {});
             assertThat(json, hasJsonPath("$.errors[0].message", containsString("Invalid fetcher name missingSlash")));
             assertThat(json, hasJsonPath("$.errors[0].extensions.exception", is(SlingGraphQLException.class.getName())));
         } finally {
@@ -173,7 +173,7 @@ public class DefaultQueryExecutorTest extends ResourceQueryTestBase {
         final ServiceRegistration<?> reg = TestUtil.registerSlingTypeResolver(context.bundleContext(), "missingSlash",
                 new DummyTypeResolver());
         try {
-            String json = queryJSON("{ currentResource { missingSlash } }", new String[] {});
+            final String json = queryJSON("{ currentResource { missingSlash } }", new String[] {});
             assertThat(json, hasJsonPath("$.errors[0].message", containsString("Invalid type resolver name missingSlash")));
             assertThat(json, hasJsonPath("$.errors[0].extensions.exception", is(SlingGraphQLException.class.getName())));
         } finally {

--- a/src/test/java/org/apache/sling/graphql/core/util/SlingGraphQLErrorHelperTest.java
+++ b/src/test/java/org/apache/sling/graphql/core/util/SlingGraphQLErrorHelperTest.java
@@ -36,14 +36,16 @@ import static org.junit.Assert.*;
 public class SlingGraphQLErrorHelperTest{
     @Test
     public void toSpecificatonTest() {
-        String customMessage = "Custom error message";
+        final String customMessage = "Custom error message";
         try {
             throw new Exception(new InvalidParameterException());
-        }catch(Exception e) {
-            List<Map<String, Object>> errors = (List<Map<String, Object>>) SlingGraphQLErrorHelper.toSpecification(customMessage, e).get(SlingGraphQLErrorHelper.GRAPHQL_ERROR_ERRORS);
+        } catch(Exception e) {
+            @SuppressWarnings("unchecked")
+            final List<Map<String, Object>> errors = (List<Map<String, Object>>) SlingGraphQLErrorHelper.toSpecification(customMessage, e).get(SlingGraphQLErrorHelper.GRAPHQL_ERROR_ERRORS);
             assertEquals(e.getMessage(), errors.get(0).get(SlingGraphQLErrorHelper.GRAPHQL_ERROR_MESSAGE));
 
-            Map<String, Object> extensions = (Map<String, Object>) errors.get(0).get(SlingGraphQLErrorHelper.GRAPHQL_ERROR_EXTENSIONS);
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> extensions = (Map<String, Object>) errors.get(0).get(SlingGraphQLErrorHelper.GRAPHQL_ERROR_EXTENSIONS);
             assertEquals(customMessage, extensions.get(SlingGraphQLErrorHelper.GRAPHQL_ERROR_DETAIL));
             assertEquals(InvalidParameterException.class.getName(), extensions.get(SlingGraphQLErrorHelper.GRAPHQL_ERROR_CAUSE));
         }

--- a/src/test/java/org/apache/sling/graphql/core/util/SlingGraphQLErrorHelperTest.java
+++ b/src/test/java/org/apache/sling/graphql/core/util/SlingGraphQLErrorHelperTest.java
@@ -1,0 +1,51 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Licensed to the Apache Software Foundation (ASF) under one
+ ~ or more contributor license agreements.  See the NOTICE file
+ ~ distributed with this work for additional information
+ ~ regarding copyright ownership.  The ASF licenses this file
+ ~ to you under the Apache License, Version 2.0 (the
+ ~ "License"); you may not use this file except in compliance
+ ~ with the License.  You may obtain a copy of the License at
+ ~
+ ~   http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package org.apache.sling.graphql.core.util;
+
+import graphql.GraphqlErrorHelper;
+import org.apache.sling.graphql.core.engine.ResourceQueryTestBase;
+import org.apache.sling.graphql.core.mocks.*;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.security.InvalidParameterException;
+import java.util.*;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SlingGraphQLErrorHelperTest{
+    @Test
+    public void toSpecificatonTest() {
+        String customMessage = "Custom error message";
+        try {
+            throw new Exception(new InvalidParameterException());
+        }catch(Exception e) {
+            List<Map<String, Object>> errors = (List<Map<String, Object>>) SlingGraphQLErrorHelper.toSpecification(customMessage, e).get(SlingGraphQLErrorHelper.GRAPHQL_ERROR_ERRORS);
+            assertEquals(e.getMessage(), errors.get(0).get(SlingGraphQLErrorHelper.GRAPHQL_ERROR_MESSAGE));
+
+            Map<String, Object> extensions = (Map<String, Object>) errors.get(0).get(SlingGraphQLErrorHelper.GRAPHQL_ERROR_EXTENSIONS);
+            assertEquals(customMessage, extensions.get(SlingGraphQLErrorHelper.GRAPHQL_ERROR_DETAIL));
+            assertEquals(InvalidParameterException.class.getName(), extensions.get(SlingGraphQLErrorHelper.GRAPHQL_ERROR_CAUSE));
+        }
+    }
+}


### PR DESCRIPTION
Problem description: https://issues.apache.org/jira/browse/SLING-9877

- Instead of throwing up exceptions in all cases, capture the error details in a map to be returned as GraphQL error response
- Added a helper utility class 