### PR TITLE
SLING-10018 Implement SelectionSet / SelectedField wrappers

### DIFF
--- a/src/main/java/org/apache/sling/graphql/api/SelectedField.java
+++ b/src/main/java/org/apache/sling/graphql/api/SelectedField.java
@@ -31,7 +31,7 @@ public interface SelectedField {
     /**
      * @return the name as defined in the selection set.
      */
-    @NotNull
+    @Nullable
     String getName();
 
     /**

--- a/src/main/java/org/apache/sling/graphql/api/SelectedField.java
+++ b/src/main/java/org/apache/sling/graphql/api/SelectedField.java
@@ -20,12 +20,17 @@ package org.apache.sling.graphql.api;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.osgi.annotation.versioning.ProviderType;
 
 import java.util.List;
 
 /**
- * Interface to wrap GraphQL SelectedField.
+ * Interface to wrap information from <a href="https://javadoc.io/doc/com.graphql-java/graphql-java/latest/graphql/schema/SelectedField.html">GraphQL SelectedField</a>.
+ *
+ * <p>As described in {@link org.apache.sling.graphql.api.SelectionSet SelectionSet}, it is aimed to map the SelectedField to the minimum information
+ * required when processing the query.</p><p>InlineFragment are mapped so that its isInline() is return true.</p>
  */
+@ProviderType
 public interface SelectedField {
 
     /**
@@ -41,18 +46,20 @@ public interface SelectedField {
     List<SelectedField> getSubSelectedFields();
 
     /**
-     * @return the sub selected field for given name.
+     * @param name the sub selected field name.
+     * @return the object or null if that doesn't exist.
      */
     @Nullable
     SelectedField getSubSelectedField(String name);
 
     /**
-     * @return true if the sub selected fields exists.
+     * @param name the sub selected field name(s).
+     * @return true if any of the sub selected fields exists.
      */
     boolean hasSubSelectedFields(String ...name);
 
     /**
-     * @return true if this field is an inline (... on Something { }).
+     * @return true if this field is an inline (i.e: ... on Something { }).
      */
     boolean isInline();
 }

--- a/src/main/java/org/apache/sling/graphql/api/SelectedField.java
+++ b/src/main/java/org/apache/sling/graphql/api/SelectedField.java
@@ -36,6 +36,11 @@ public interface SelectedField {
     List<SelectedField> getSubSelectedField();
 
     /**
+     * @return true if the sub selected fields exists.
+     */
+    boolean hasSubSelectedFields(String ...name);
+
+    /**
      * @return true if this field is an inline (... on Something { }).
      */
     boolean isInline();

--- a/src/main/java/org/apache/sling/graphql/api/SelectedField.java
+++ b/src/main/java/org/apache/sling/graphql/api/SelectedField.java
@@ -18,6 +18,9 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package org.apache.sling.graphql.api;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import java.util.List;
 
 /**
@@ -28,16 +31,19 @@ public interface SelectedField {
     /**
      * @return the name as defined in the selection set.
      */
+    @NotNull
     String getName();
 
     /**
      * @return the sub selected fields.
      */
+    @NotNull
     List<SelectedField> getSubSelectedFields();
 
     /**
      * @return the sub selected field for given name.
      */
+    @Nullable
     SelectedField getSubSelectedField(String name);
 
     /**

--- a/src/main/java/org/apache/sling/graphql/api/SelectedField.java
+++ b/src/main/java/org/apache/sling/graphql/api/SelectedField.java
@@ -18,7 +18,7 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package org.apache.sling.graphql.api;
 
-import org.jetbrains.annotations.Nullable;
+import java.util.List;
 
 /**
  * Interface to wrap GraphQL SelectedField.
@@ -31,8 +31,12 @@ public interface SelectedField {
     String getName();
 
     /**
-     * @return the sub selection set. Null if no sub selection is available.
+     * @return the sub selected fields.
      */
-    @Nullable SelectionSet getSelectionSet();
+    List<SelectedField> getSubSelectedField();
 
+    /**
+     * @return true if this field is an inline (... on Something { }).
+     */
+    boolean isInline();
 }

--- a/src/main/java/org/apache/sling/graphql/api/SelectedField.java
+++ b/src/main/java/org/apache/sling/graphql/api/SelectedField.java
@@ -1,0 +1,38 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Licensed to the Apache Software Foundation (ASF) under one
+ ~ or more contributor license agreements.  See the NOTICE file
+ ~ distributed with this work for additional information
+ ~ regarding copyright ownership.  The ASF licenses this file
+ ~ to you under the Apache License, Version 2.0 (the
+ ~ "License"); you may not use this file except in compliance
+ ~ with the License.  You may obtain a copy of the License at
+ ~
+ ~   http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package org.apache.sling.graphql.api;
+
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Interface to wrap GraphQL SelectedField.
+ */
+public interface SelectedField {
+
+    /**
+     * @return the name as defined in the selection set.
+     */
+    String getName();
+
+    /**
+     * @return the sub selection set. Null if no sub selection is available.
+     */
+    @Nullable SelectionSet getSelectionSet();
+
+}

--- a/src/main/java/org/apache/sling/graphql/api/SelectedField.java
+++ b/src/main/java/org/apache/sling/graphql/api/SelectedField.java
@@ -33,7 +33,12 @@ public interface SelectedField {
     /**
      * @return the sub selected fields.
      */
-    List<SelectedField> getSubSelectedField();
+    List<SelectedField> getSubSelectedFields();
+
+    /**
+     * @return the sub selected field for given name.
+     */
+    SelectedField getSubSelectedField(String name);
 
     /**
      * @return true if the sub selected fields exists.

--- a/src/main/java/org/apache/sling/graphql/api/SelectionSet.java
+++ b/src/main/java/org/apache/sling/graphql/api/SelectionSet.java
@@ -20,12 +20,35 @@ package org.apache.sling.graphql.api;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.osgi.annotation.versioning.ProviderType;
 
 import java.util.List;
 
 /**
- * Interface to wrap GraphQL DataFetchingFieldSelectionSet.
+ * Interface to wrap information from <a href="https://javadoc.io/doc/com.graphql-java/graphql-java/latest/graphql/schema/DataFetchingFieldSelectionSet.html">GraphQL DataFetchingFieldSelectionSet</a>.
+ * <p>Mainly it keeps information about fields name that got selected.</p>
+ * <pre>
+ * For example:
+ * {@code
+ *   queryName {
+ *       field1
+ *       field2 {
+ *           ... on Type1 {
+ *               field3
+ *           }
+ *       }
+ *       field4
+ *   }
+ * }
+ * </pre>
+ *
+ * <p>Would result in a mapping with corresponding SelectedField(s).</p>
+ * <p><b>field1</b> would be accessible with qualified name "field1"
+ * while <b>field3</b> would be accessible with qualified name "field2/Type1/field3"
+ * </p>
+ * <p><b>Type1</b> would be a SelectedField with isInline() returning true</p>
  */
+@ProviderType
 public interface SelectionSet {
 
     /**

--- a/src/main/java/org/apache/sling/graphql/api/SelectionSet.java
+++ b/src/main/java/org/apache/sling/graphql/api/SelectionSet.java
@@ -31,7 +31,12 @@ public interface SelectionSet {
     List<SelectedField> getFields();
 
     /**
-     * @return true if it has any fields.
+     * @return true if the field qualified name exist.
      */
-    boolean hasFields();
+    boolean contains(String qualifiedName);
+
+    /**
+     * @return SelectedField for qualified name.
+     */
+    SelectedField get(String qualifiedName);
 }

--- a/src/main/java/org/apache/sling/graphql/api/SelectionSet.java
+++ b/src/main/java/org/apache/sling/graphql/api/SelectionSet.java
@@ -38,6 +38,12 @@ import java.util.List;
  *           }
  *       }
  *       field4
+ *       field5 {
+ *           field6
+ *           field7 {
+ *               field8
+ *           }
+ *       }
  *   }
  * }
  * </pre>
@@ -45,6 +51,7 @@ import java.util.List;
  * <p>Would result in a mapping with corresponding SelectedField(s).</p>
  * <p><b>field1</b> would be accessible with qualified name "field1"
  * while <b>field3</b> would be accessible with qualified name "field2/Type1/field3"
+ * and <b>field8</b> would be accessible with qualified name "field5/field7/field8"
  * </p>
  * <p><b>Type1</b> would be a SelectedField with isInline() returning true</p>
  */

--- a/src/main/java/org/apache/sling/graphql/api/SelectionSet.java
+++ b/src/main/java/org/apache/sling/graphql/api/SelectionSet.java
@@ -18,6 +18,9 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package org.apache.sling.graphql.api;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import java.util.List;
 
 /**
@@ -28,6 +31,7 @@ public interface SelectionSet {
     /**
      * @return the immediate list of fields in the selection.
      */
+    @NotNull
     List<SelectedField> getFields();
 
     /**
@@ -38,5 +42,6 @@ public interface SelectionSet {
     /**
      * @return SelectedField for qualified name.
      */
+    @Nullable
     SelectedField get(String qualifiedName);
 }

--- a/src/main/java/org/apache/sling/graphql/api/SelectionSet.java
+++ b/src/main/java/org/apache/sling/graphql/api/SelectionSet.java
@@ -1,0 +1,37 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Licensed to the Apache Software Foundation (ASF) under one
+ ~ or more contributor license agreements.  See the NOTICE file
+ ~ distributed with this work for additional information
+ ~ regarding copyright ownership.  The ASF licenses this file
+ ~ to you under the Apache License, Version 2.0 (the
+ ~ "License"); you may not use this file except in compliance
+ ~ with the License.  You may obtain a copy of the License at
+ ~
+ ~   http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package org.apache.sling.graphql.api;
+
+import java.util.List;
+
+/**
+ * Interface to wrap GraphQL DataFetchingFieldSelectionSet.
+ */
+public interface SelectionSet {
+
+    /**
+     * @return the immediate list of fields in the selection.
+     */
+    List<SelectedField> getFields();
+
+    /**
+     * @return true if it has any fields.
+     */
+    boolean hasFields();
+}

--- a/src/main/java/org/apache/sling/graphql/api/SlingDataFetcherEnvironment.java
+++ b/src/main/java/org/apache/sling/graphql/api/SlingDataFetcherEnvironment.java
@@ -20,6 +20,7 @@
 package org.apache.sling.graphql.api;
 
 import java.util.Map;
+
 import org.apache.sling.api.resource.Resource;
 import org.jetbrains.annotations.Nullable;
 import org.osgi.annotation.versioning.ProviderType;
@@ -64,4 +65,7 @@ public interface SlingDataFetcherEnvironment {
     /** @return the source, if set by the schema directive */
     @Nullable
     String getFetcherSource();
+
+    /** @return the selectionSet, mandatory in a graphql query */
+    SelectionSet getSelectionSet();
 }

--- a/src/main/java/org/apache/sling/graphql/api/package-info.java
+++ b/src/main/java/org/apache/sling/graphql/api/package-info.java
@@ -21,6 +21,6 @@
   * This package contains APIs which are independent of
   * a specific implementation of the underlying graphQL engine.
   */
-@Version("3.2.0")
+@Version("3.3.0")
 package org.apache.sling.graphql.api;
 import org.osgi.annotation.versioning.Version;

--- a/src/main/java/org/apache/sling/graphql/core/engine/DataFetchingEnvironmentWrapper.java
+++ b/src/main/java/org/apache/sling/graphql/core/engine/DataFetchingEnvironmentWrapper.java
@@ -21,7 +21,6 @@ package org.apache.sling.graphql.core.engine;
 
 import java.util.Map;
 
-import graphql.schema.DataFetchingFieldSelectionSet;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.graphql.api.SelectionSet;
 import org.apache.sling.graphql.api.SlingDataFetcherEnvironment;

--- a/src/main/java/org/apache/sling/graphql/core/engine/DataFetchingEnvironmentWrapper.java
+++ b/src/main/java/org/apache/sling/graphql/core/engine/DataFetchingEnvironmentWrapper.java
@@ -21,7 +21,9 @@ package org.apache.sling.graphql.core.engine;
 
 import java.util.Map;
 
+import graphql.schema.DataFetchingFieldSelectionSet;
 import org.apache.sling.api.resource.Resource;
+import org.apache.sling.graphql.api.SelectionSet;
 import org.apache.sling.graphql.api.SlingDataFetcherEnvironment;
 
 import graphql.schema.DataFetchingEnvironment;
@@ -35,12 +37,14 @@ class DataFetchingEnvironmentWrapper implements SlingDataFetcherEnvironment {
     private final Resource currentResource;
     private final String options;
     private final String source;
+    private final SelectionSet selectionSet;
 
     DataFetchingEnvironmentWrapper(DataFetchingEnvironment env, Resource currentResource, String options, String source) {
         this.env = env;
         this.currentResource = currentResource;
         this.options = options;
         this.source = source;
+        this.selectionSet = new SelectionSetWrapper(env.getSelectionSet());
     }
 
     @Override
@@ -76,5 +80,10 @@ class DataFetchingEnvironmentWrapper implements SlingDataFetcherEnvironment {
     @Override
     public String getFetcherSource() {
         return source;
+    }
+
+    @Override
+    public SelectionSet getSelectionSet() {
+        return selectionSet;
     }
 }

--- a/src/main/java/org/apache/sling/graphql/core/engine/SelectedFieldWrapper.java
+++ b/src/main/java/org/apache/sling/graphql/core/engine/SelectedFieldWrapper.java
@@ -1,0 +1,51 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Licensed to the Apache Software Foundation (ASF) under one
+ ~ or more contributor license agreements.  See the NOTICE file
+ ~ distributed with this work for additional information
+ ~ regarding copyright ownership.  The ASF licenses this file
+ ~ to you under the Apache License, Version 2.0 (the
+ ~ "License"); you may not use this file except in compliance
+ ~ with the License.  You may obtain a copy of the License at
+ ~
+ ~   http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package org.apache.sling.graphql.core.engine;
+
+import graphql.schema.DataFetchingFieldSelectionSet;
+import org.apache.sling.graphql.api.SelectedField;
+import org.apache.sling.graphql.api.SelectionSet;
+
+/**
+ * Implement a wrapper for GraphQL SelectedField.
+ */
+public class SelectedFieldWrapper implements SelectedField {
+
+    private final String name;
+    private SelectionSetWrapper subSelectionSet;
+
+    public SelectedFieldWrapper(graphql.schema.SelectedField field) {
+        this.name = field.getName();
+        DataFetchingFieldSelectionSet subSelectionSet = field.getSelectionSet();
+        if (subSelectionSet != null) {
+            this.subSelectionSet = new SelectionSetWrapper(subSelectionSet);
+        }
+
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public SelectionSet getSelectionSet() {
+        return subSelectionSet;
+    }
+}

--- a/src/main/java/org/apache/sling/graphql/core/engine/SelectedFieldWrapper.java
+++ b/src/main/java/org/apache/sling/graphql/core/engine/SelectedFieldWrapper.java
@@ -67,13 +67,18 @@ public class SelectedFieldWrapper implements SelectedField {
     }
 
     @Override
-    public List<SelectedField> getSubSelectedField() {
+    public List<SelectedField> getSubSelectedFields() {
         return subFields;
     }
 
     @Override
+    public SelectedField getSubSelectedField(String name) {
+        return subFieldMap.get(name);
+    }
+
+    @Override
     public boolean hasSubSelectedFields(String... name) {
-        return Arrays.stream(name).allMatch(subFieldMap::containsKey);
+        return Arrays.stream(name).anyMatch(subFieldMap::containsKey);
     }
 
     @Override

--- a/src/main/java/org/apache/sling/graphql/core/engine/SelectedFieldWrapper.java
+++ b/src/main/java/org/apache/sling/graphql/core/engine/SelectedFieldWrapper.java
@@ -27,6 +27,7 @@ import org.apache.sling.graphql.api.SelectedField;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -36,7 +37,7 @@ public class SelectedFieldWrapper implements SelectedField {
 
     private String name;
     private boolean isInline;
-    private HashMap<String, SelectedField> subFieldMap = new HashMap<>();
+    private Map<String, SelectedField> subFieldMap = new HashMap<>();
     private List<SelectedField> subFields;
 
     public SelectedFieldWrapper(Selection selection) {

--- a/src/main/java/org/apache/sling/graphql/core/engine/SelectionSetWrapper.java
+++ b/src/main/java/org/apache/sling/graphql/core/engine/SelectionSetWrapper.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Implement a wrapper for GraphQL DataFetchingFieldSelectionSet.
@@ -36,7 +37,7 @@ public class SelectionSetWrapper implements SelectionSet {
 
     private List<SelectedField> fields = new ArrayList<>();
 
-    private HashMap<String, SelectedField> fieldsMap = new HashMap<>();
+    private Map<String, SelectedField> fieldsMap = new HashMap<>();
 
     public SelectionSetWrapper(@Nullable DataFetchingFieldSelectionSet selectionSet) {
         if (selectionSet != null) {

--- a/src/main/java/org/apache/sling/graphql/core/engine/SelectionSetWrapper.java
+++ b/src/main/java/org/apache/sling/graphql/core/engine/SelectionSetWrapper.java
@@ -1,0 +1,52 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Licensed to the Apache Software Foundation (ASF) under one
+ ~ or more contributor license agreements.  See the NOTICE file
+ ~ distributed with this work for additional information
+ ~ regarding copyright ownership.  The ASF licenses this file
+ ~ to you under the Apache License, Version 2.0 (the
+ ~ "License"); you may not use this file except in compliance
+ ~ with the License.  You may obtain a copy of the License at
+ ~
+ ~   http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package org.apache.sling.graphql.core.engine;
+
+import graphql.schema.DataFetchingFieldSelectionSet;
+import org.apache.sling.graphql.api.SelectedField;
+import org.apache.sling.graphql.api.SelectionSet;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Implement a wrapper for GraphQL DataFetchingFieldSelectionSet.
+ */
+public class SelectionSetWrapper implements SelectionSet {
+
+    private List<SelectedField> fields = Collections.EMPTY_LIST;
+
+    public SelectionSetWrapper(@Nullable DataFetchingFieldSelectionSet selectionSet) {
+        if (selectionSet != null) {
+            this.fields = selectionSet.getFields().stream().map(SelectedFieldWrapper::new).collect(Collectors.toList());
+        }
+    }
+
+    @Override
+    public List<SelectedField> getFields() {
+        return fields;
+    }
+
+    @Override
+    public boolean hasFields() {
+        return !fields.isEmpty();
+    }
+}

--- a/src/main/java/org/apache/sling/graphql/core/engine/SelectionSetWrapper.java
+++ b/src/main/java/org/apache/sling/graphql/core/engine/SelectionSetWrapper.java
@@ -47,7 +47,7 @@ public class SelectionSetWrapper implements SelectionSet {
         parentList.forEach(s -> {
            String qualifiedName = qualifiedPath + s.getName();
            fieldsMap.put(qualifiedName, s);
-           initFlatMap(s.getSubSelectedField(), qualifiedName + "/");
+           initFlatMap(s.getSubSelectedFields(), qualifiedName + "/");
         });
     }
 

--- a/src/main/java/org/apache/sling/graphql/core/engine/SelectionSetWrapper.java
+++ b/src/main/java/org/apache/sling/graphql/core/engine/SelectionSetWrapper.java
@@ -21,9 +21,11 @@ package org.apache.sling.graphql.core.engine;
 import graphql.schema.DataFetchingFieldSelectionSet;
 import org.apache.sling.graphql.api.SelectedField;
 import org.apache.sling.graphql.api.SelectionSet;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
@@ -38,7 +40,7 @@ public class SelectionSetWrapper implements SelectionSet {
 
     public SelectionSetWrapper(@Nullable DataFetchingFieldSelectionSet selectionSet) {
         if (selectionSet != null) {
-            selectionSet.get().getSubFieldsList().stream().forEach(s -> fields.add(new SelectedFieldWrapper(s.getSingleField())));
+            selectionSet.get().getSubFieldsList().forEach(s -> fields.add(new SelectedFieldWrapper(s.getSingleField())));
             initFlatMap(fields, "");
         }
     }
@@ -52,8 +54,9 @@ public class SelectionSetWrapper implements SelectionSet {
     }
 
     @Override
+    @NotNull
     public List<SelectedField> getFields() {
-        return fields;
+        return Collections.unmodifiableList(fields);
     }
 
     @Override

--- a/src/test/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutorTest.java
+++ b/src/test/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutorTest.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.Dictionary;
 import java.util.Hashtable;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.sling.graphql.api.SchemaProvider;
 import org.apache.sling.graphql.api.SelectionSet;
@@ -74,6 +75,7 @@ public class DefaultQueryExecutorTest extends ResourceQueryTestBase {
         TestUtil.registerSlingDataFetcher(context.bundleContext(), "test/static", new EchoDataFetcher(staticData));
         TestUtil.registerSlingDataFetcher(context.bundleContext(), "test/fortyTwo", new EchoDataFetcher(42));
         TestUtil.registerSlingDataFetcher(context.bundleContext(), "sling/digest", new DigestDataFetcher());
+        TestUtil.registerSlingDataFetcher(context.bundleContext(), "combined/fetcher", new EchoDataFetcher(unionData));
     }
 
     @Test
@@ -194,27 +196,62 @@ public class DefaultQueryExecutorTest extends ResourceQueryTestBase {
 
     @Test
     public void selectionSetTest() throws Exception {
-        queryJSON("{ unionFetcher { items { ... on Test { testingArgument }  ... on SlingResource { path }} } }");
+        queryJSON("{ combinedFetcher { boolValue resourcePath aTest { boolValue test resourcePath } allTests { boolValue test resourcePath } items { ... on Test { testingArgument }  ... on SlingResource { path }} } }");
 
         // retrieve the service used
-        ServiceReference<?>[] serviceReferences = context.bundleContext().getServiceReferences(SlingDataFetcher.class.getName(), "(name=union/fetcher)");
+        ServiceReference<?>[] serviceReferences = context.bundleContext().getServiceReferences(SlingDataFetcher.class.getName(), "(name=combined/fetcher)");
         EchoDataFetcher echoDataFetcher = (EchoDataFetcher) context.bundleContext().getService(serviceReferences[0]);
 
         // Access the computed SelectionSet
         SelectionSet selectionSet = echoDataFetcher.getSelectionSet();
 
         // Assert it contains the expected results
-        assertTrue(selectionSet.contains("items"));
-        assertTrue(selectionSet.contains("items/Test"));
-        assertTrue(selectionSet.contains("items/Test/testingArgument"));
-        assertTrue(selectionSet.contains("items/SlingResource"));
-        assertTrue(selectionSet.contains("items/SlingResource/path"));
+        String[] expectedQualifiedName = new String[] {
+                "boolValue",
+                "resourcePath",
+                "aTest",
+                "aTest/test",
+                "aTest/boolValue",
+                "aTest/resourcePath",
+                "allTests",
+                "allTests/test",
+                "allTests/boolValue",
+                "allTests/resourcePath",
+                "items",
+                "items/Test",
+                "items/Test/testingArgument",
+                "items/SlingResource",
+                "items/SlingResource/path"
+        };
+        for (String expectedQN : expectedQualifiedName) {
+            assertTrue(selectionSet.contains(expectedQN));
+        }
 
-        assertFalse(selectionSet.get("items").isInline());
-        assertFalse(selectionSet.get("items/Test/testingArgument").isInline());
-        assertFalse(selectionSet.get("items/SlingResource/path").isInline());
+        String[] expectedNonInlineQNs = new String[] {
+                "boolValue",
+                "resourcePath",
+                "aTest",
+                "aTest/test",
+                "aTest/boolValue",
+                "aTest/resourcePath",
+                "allTests",
+                "allTests/test",
+                "allTests/boolValue",
+                "allTests/resourcePath",
+                "items",
+                "items/Test/testingArgument",
+                "items/SlingResource/path"
+        };
+        for (String expectedNonInlineQN : expectedNonInlineQNs) {
+            assertFalse(Objects.requireNonNull(selectionSet.get(expectedNonInlineQN)).isInline());
+        }
 
-        assertTrue(selectionSet.get("items/Test").isInline());
-        assertTrue(selectionSet.get("items/SlingResource").isInline());
+        String[] expectedInlineQNs = new String[] {
+                "items/Test",
+                "items/SlingResource"
+        };
+        for (String expectedInlineQN : expectedInlineQNs) {
+            assertTrue(Objects.requireNonNull(selectionSet.get(expectedInlineQN)).isInline());
+        }
     }
 }

--- a/src/test/java/org/apache/sling/graphql/core/mocks/EchoDataFetcher.java
+++ b/src/test/java/org/apache/sling/graphql/core/mocks/EchoDataFetcher.java
@@ -19,12 +19,14 @@
 
 package org.apache.sling.graphql.core.mocks;
 
+import org.apache.sling.graphql.api.SelectionSet;
 import org.apache.sling.graphql.api.SlingDataFetcher;
 import org.apache.sling.graphql.api.SlingDataFetcherEnvironment;
 
 public class EchoDataFetcher implements SlingDataFetcher<Object> {
 
     private final Object data;
+    private SelectionSet selectionSet;
 
     public EchoDataFetcher(Object data) {
         this.data = data;
@@ -37,6 +39,11 @@ public class EchoDataFetcher implements SlingDataFetcher<Object> {
         } else if(data == null) {
             return e.getCurrentResource();
         }
+        selectionSet = e.getSelectionSet();
         return data;
+    }
+
+    public SelectionSet getSelectionSet() {
+        return selectionSet;
     }
 }

--- a/src/test/resources/test-schema.txt
+++ b/src/test/resources/test-schema.txt
@@ -38,6 +38,9 @@ type Query {
 
     # Test union as return type
     unionFetcher: Test2 @fetcher(name:"union/fetcher")
+
+    # Test combined as return type
+    combinedFetcher: Test3 @fetcher(name:"combined/fetcher")
 }
 
 union AllTypes @resolver(name:"union/resolver" source:"AllTypes") = SlingResource | Test
@@ -74,3 +77,10 @@ type Test2 {
     items: [AllTypes]
 }
 
+type Test3 {
+    boolValue: Boolean
+    resourcePath: String
+    aTest: Test
+    allTests: [Test]
+    items: [AllTypes]
+}


### PR DESCRIPTION
- Defining 2 new interfaces (SelectedField and SelectionSet) to wrap GraphQL related DataFetching objects.
- Changed the SlingDataFetcherEnvironment to return the SelectionSet wrapper
- Changed the DataFetchingEnvironmentWrapper to wrap the SelectionSet in the returned wrapper.
- Added 2 implementing wrapper for SelectedFieldWrapper  and SelectionSetWrapper.
- Added a unit test