### PR TITLE
SLING-10883 - Update the GraphQL implementation to use the Builder API for internal requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,13 +136,13 @@
     <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.api</artifactId>
-      <version>2.18.4</version>
+      <version>2.23.7-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.engine</artifactId>
-      <version>2.6.22</version>
+      <version>2.7.10</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -183,12 +183,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.sling</groupId>
-      <artifactId>org.apache.sling.scripting.core</artifactId>
-      <version>2.0.30</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.commons.osgi</artifactId>
       <version>2.4.0</version>
       <scope>provided</scope>
@@ -207,12 +201,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.sling</groupId>
-      <artifactId>org.apache.sling.servlet-helpers</artifactId>
-      <version>1.4.2</version>
       <scope>provided</scope>
     </dependency>
 
@@ -313,6 +301,48 @@
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <version>1.2.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.jcr.jackrabbit.usermanager</artifactId>
+      <version>2.2.15-SNAPSHOT</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.resourceresolver</artifactId>
+      <version>1.7.10</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.servlets.resolver</artifactId>
+      <version>2.8.3-SNAPSHOT</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.commons.compiler</artifactId>
+      <version>2.4.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.scripting.spi</artifactId>
+      <version>1.0.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.scripting.core</artifactId>
+      <version>2.4.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.util.converter</artifactId>
+      <version>1.0.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
     <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.api</artifactId>
-      <version>2.23.7-SNAPSHOT</version>
+      <version>2.24.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -306,19 +306,19 @@
     <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.jcr.jackrabbit.usermanager</artifactId>
-      <version>2.2.15-SNAPSHOT</version>
+      <version>2.2.16</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.resourceresolver</artifactId>
-      <version>1.7.10</version>
+      <version>1.8.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.servlets.resolver</artifactId>
-      <version>2.8.3-SNAPSHOT</version>
+      <version>2.9.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/org/apache/sling/graphql/core/it/GraphQLServletIT.java
+++ b/src/test/java/org/apache/sling/graphql/core/it/GraphQLServletIT.java
@@ -45,10 +45,10 @@ import org.apache.http.impl.client.BasicAuthCache;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.sling.api.request.builder.SlingHttpServletResponseResult;
 import org.apache.sling.graphql.api.SchemaProvider;
 import org.apache.sling.graphql.core.mocks.ReplacingSchemaProvider;
 import org.apache.sling.resource.presence.ResourcePresence;
-import org.apache.sling.servlethelpers.MockSlingHttpServletResponse;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Configuration;
@@ -61,8 +61,8 @@ import org.osgi.framework.BundleContext;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -126,7 +126,7 @@ public class GraphQLServletIT extends GraphQLCoreTestSupport {
     @Test
     public void testPersistedQueriesBasic() throws Exception {
         String queryHash = "a16982712f6ecdeba5d950d42e3c13df0fc26d008c497f6bf012701b57e02a51";
-        MockSlingHttpServletResponse response = persistQuery("/graphql/two.gql", "{ currentResource { resourceType name } }", null);
+        SlingHttpServletResponseResult response = persistQuery("/graphql/two.gql", "{ currentResource { resourceType name } }", null);
         assertEquals("Expected to have stored a persisted query.", 201, response.getStatus());
         assertEquals("The value of the Location header does not look correct.",
                 "http://localhost/graphql/two.gql/persisted/" + queryHash + ".gql",
@@ -227,7 +227,7 @@ public class GraphQLServletIT extends GraphQLCoreTestSupport {
 
     @Test
     public void testMissingQuery() throws Exception {
-        MockSlingHttpServletResponse response = executeRequest("GET", "/graphql/two.gql", null, null, null, -1);
+        SlingHttpServletResponseResult response = executeRequest("GET", "/graphql/two.gql", null, null, null, -1);
         assertEquals(400, response.getStatus());
     }
 

--- a/src/test/java/org/apache/sling/graphql/core/it/GraphQLServletNoConfigIT.java
+++ b/src/test/java/org/apache/sling/graphql/core/it/GraphQLServletNoConfigIT.java
@@ -20,8 +20,8 @@ package org.apache.sling.graphql.core.it;
 
 import javax.inject.Inject;
 
+import org.apache.sling.api.request.builder.SlingHttpServletResponseResult;
 import org.apache.sling.resource.presence.ResourcePresence;
-import org.apache.sling.servlethelpers.MockSlingHttpServletResponse;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Configuration;
@@ -55,7 +55,7 @@ public class GraphQLServletNoConfigIT extends GraphQLCoreTestSupport {
     @Test
     public void testServletDisabledByDefault() throws Exception {
         final String path = "/graphql/one";
-        MockSlingHttpServletResponse response = executeRequest("GET", path + ".json", null, null, null, -1);
+        SlingHttpServletResponseResult response = executeRequest("GET", path + ".json", null, null, null, -1);
         assertEquals(200, response.getStatus());
 
         response = executeRequest("GET", path + ".gql", null, null, null, -1);


### PR DESCRIPTION
* refactored code to switch to the o.a.s.api.request.builder API