### PR TITLE
SLING-11248 QueryParser.fromRequest(...) calls possible exceptions sh…

### DIFF
--- a/src/main/java/org/apache/sling/graphql/core/servlet/GraphQLServlet.java
+++ b/src/main/java/org/apache/sling/graphql/core/servlet/GraphQLServlet.java
@@ -29,7 +29,6 @@ import java.util.regex.Pattern;
 import javax.json.Json;
 import javax.json.JsonException;
 import javax.json.JsonWriter;
-import javax.json.stream.JsonParsingException;
 import javax.servlet.Servlet;
 import javax.servlet.http.HttpServletResponse;
 

--- a/src/main/java/org/apache/sling/graphql/core/servlet/GraphQLServlet.java
+++ b/src/main/java/org/apache/sling/graphql/core/servlet/GraphQLServlet.java
@@ -27,7 +27,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.json.Json;
+import javax.json.JsonException;
 import javax.json.JsonWriter;
+import javax.json.stream.JsonParsingException;
 import javax.servlet.Servlet;
 import javax.servlet.http.HttpServletResponse;
 
@@ -304,7 +306,17 @@ public class GraphQLServlet extends SlingAllMethodsServlet {
     private void execute(Resource resource, SlingHttpServletRequest request, SlingHttpServletResponse response) throws IOException {
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
-        final QueryParser.Result result = QueryParser.fromRequest(request);
+        QueryParser.Result result = null;
+        try {
+            result = QueryParser.fromRequest(request);
+        } catch (IllegalStateException | JsonException err) {
+            response.sendError(
+                HttpServletResponse.SC_BAD_REQUEST,
+                "Error while parsing query  from request due to: " + err.getMessage()
+            );
+            return;
+        }
+
         if (result == null) {
             response.sendError(HttpServletResponse.SC_BAD_REQUEST);
             return;

--- a/src/test/java/org/apache/sling/graphql/core/servlet/GraphQLServletTest.java
+++ b/src/test/java/org/apache/sling/graphql/core/servlet/GraphQLServletTest.java
@@ -174,7 +174,7 @@ public class GraphQLServletTest {
         assertEquals(0.5f, metricRegistry.getGauges().get(expectedMetric).getValue());
     }
 
-    private void assertPostWithBody(String contentType, int expectedStatus) throws IOException {
+    private void assertPostWithBody(String contentType, String query, int expectedStatus) throws IOException {
         context.registerInjectActivateService(new SimpleGraphQLCacheProvider());
         context.registerInjectActivateService(new GraphQLServlet(), ServletResolverConstants.SLING_SERVLET_RESOURCE_TYPES, TEST_RESOURCE_TYPE,
                 "persistedQueries.suffix", "");
@@ -185,7 +185,7 @@ public class GraphQLServletTest {
         MockSlingHttpServletRequest request = new MockSlingHttpServletRequest(context.bundleContext());
 
         request.setMethod("POST");
-        request.setContent(TEST_QUERY.getBytes(StandardCharsets.UTF_8));
+        request.setContent(query.getBytes(StandardCharsets.UTF_8));
         request.setContentType(contentType);
 
         request.setResource(resource);
@@ -199,21 +199,29 @@ public class GraphQLServletTest {
 
     @Test
     public void testBasicJsonContentType() throws IOException {
-        assertPostWithBody("application/json", 200);
+        assertPostWithBody("application/json", TEST_QUERY, 200);
     }
 
     @Test
     public void testJsonContentTypeWithCharset() throws IOException {
-        assertPostWithBody("application/json  ; charset=UTF-8", 200);
+        assertPostWithBody("application/json  ; charset=UTF-8", TEST_QUERY,200);
     }
 
     @Test
     public void testNoContentType() throws IOException {
-        assertPostWithBody(null, 400);
+        assertPostWithBody(null, TEST_QUERY, 400);
     }
 
     @Test
     public void testWrongContentType() throws IOException {
-        assertPostWithBody("text/html", 400);
+        assertPostWithBody("text/html", TEST_QUERY, 400);
+    }
+
+    /**
+     * SLING-11248 NothingToRead exception should return 400.
+     */
+    @Test
+    public void testEmptyQueryNothingToRead() throws IOException {
+        assertPostWithBody("application/json  ; charset=UTF-8", "", 400);
     }
 }


### PR DESCRIPTION
…ould be returned as 400

As described on SLING-11248 it returns 500 errors, while this kind of request should be returned with 400 as it is most likely due to a bad request.

Feel free to adjust this PR as you need it.
@raducotescu  @bdelacretaz 