### PR TITLE
SLING-11429 - OSGi configs on same resource type cause IAE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,14 +53,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>biz.aQute.bnd</groupId>
-        <artifactId>bnd-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>biz.aQute.bnd</groupId>
-        <artifactId>bnd-baseline-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <executions>
@@ -92,6 +84,11 @@
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>osgi.core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/src/test/java/org/apache/sling/graphql/core/servlet/GraphQLServletTest.java
+++ b/src/test/java/org/apache/sling/graphql/core/servlet/GraphQLServletTest.java
@@ -148,7 +148,7 @@ public class GraphQLServletTest {
         context.registerInjectActivateService(new GraphQLServlet(), ServletResolverConstants.SLING_SERVLET_RESOURCE_TYPES, TEST_RESOURCE_TYPE,
             "persistedQueries.suffix", "");
 
-        String expectedMetricPrefix = "org.apache.sling.graphql.core.servlet.GraphQLServlet.rt:" + TEST_RESOURCE_TYPE + ".m:GET.e:gql";
+        String expectedMetricPrefix = "org.apache.sling.graphql.core.GraphQLServlet.rt:" + TEST_RESOURCE_TYPE + ".m:GET.e:gql";
 
         verify(metricsService).counter(expectedMetricPrefix + ".cache_hits");
         verify(metricsService).counter(expectedMetricPrefix + ".requests_total");
@@ -163,7 +163,7 @@ public class GraphQLServletTest {
             "persistedQueries.suffix", "/persisted");
 
         // test resource type, default method, default extension
-        String expectedMetric = "org.apache.sling.graphql.core.servlet.GraphQLServlet.rt:" + TEST_RESOURCE_TYPE + ".m:GET.e:gql.cache_hit_rate";
+        String expectedMetric = "org.apache.sling.graphql.core.GraphQLServlet.rt:" + TEST_RESOURCE_TYPE + ".m:GET.e:gql.cache_hit_rate";
 
         assertTrue(metricRegistry.getGauges().containsKey(expectedMetric));
         assertEquals(0.0f, metricRegistry.getGauges().get(expectedMetric).getValue());


### PR DESCRIPTION
* use the GraphQLServlet service.pid in order to have unique instances for all the required metrics