### PR TITLE
SLING-12198 - Extending sling.graphql.engine to allow passing custom graphql ParserOptions.

### DIFF
--- a/src/main/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutor.java
+++ b/src/main/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutor.java
@@ -180,6 +180,16 @@ public class DefaultQueryExecutor implements QueryExecutor {
                     .build();
 
         }
+
+        private Consumer<GraphQLContext.Builder> getGraphQLContextBuilder() {
+            final ParserOptions parserOptions = ParserOptions.getDefaultParserOptions().transform(builder -> {
+                builder
+                        .maxTokens(maxQueryTokens)
+                        .maxWhitespaceTokens(maxWhitespaceTokens)
+                        .build();
+            });
+            return builder -> builder.put(ParserOptions.class, parserOptions);
+        }
     }
 
     @Activate
@@ -417,16 +427,6 @@ public class DefaultQueryExecutor implements QueryExecutor {
         } finally {
             readLock.unlock();
         }
-    }
-
-    private Consumer<GraphQLContext.Builder> getGraphQLContextBuilder() {
-        final ParserOptions opt = ParserOptions.getDefaultParserOptions().transform(builder -> {
-            builder
-                .maxTokens(maxQueryTokens)
-                .maxWhitespaceTokens(maxWhitespaceTokens)
-                .build();
-        });
-        return builder -> builder.put(ParserOptions.class, opt);
     }
 
     private GraphQLSchema buildSchema(@NotNull TypeDefinitionRegistry typeRegistry, @NotNull Resource currentResource) {

--- a/src/main/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutor.java
+++ b/src/main/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutor.java
@@ -418,21 +418,13 @@ public class DefaultQueryExecutor implements QueryExecutor {
     }
 
     private Consumer<GraphQLContext.Builder> getGraphQLContextBuilder() {
-        ParserOptions defaultParserOptions = ParserOptions.getDefaultParserOptions();
-        Consumer<GraphQLContext.Builder> graphQLContextBuilder = builder -> {
-            builder.put(ParserOptions.class, ParserOptions.newParserOptions()
-                    .captureIgnoredChars(defaultParserOptions.isCaptureIgnoredChars())
-                    .captureSourceLocation(defaultParserOptions.isCaptureSourceLocation())
-                    .captureLineComments(defaultParserOptions.isCaptureLineComments())
-                    .readerTrackData(defaultParserOptions.isReaderTrackData())
-                    .maxTokens(queryMaxTokens)
-                    .maxWhitespaceTokens(queryMaxWhitespaceTokens)
-                    .maxRuleDepth(defaultParserOptions.getMaxRuleDepth())
-                    .build()
-            );
-        };
-
-        return graphQLContextBuilder;
+        final ParserOptions opt = ParserOptions.getDefaultParserOptions().transform(builder -> {
+            builder
+                .maxTokens(queryMaxTokens)
+                .maxWhitespaceTokens(queryMaxWhitespaceTokens)
+                .build();
+        });
+        return builder -> builder.put(ParserOptions.class, opt);
     }
 
     private GraphQLSchema buildSchema(@NotNull TypeDefinitionRegistry typeRegistry, @NotNull Resource currentResource) {

--- a/src/main/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutor.java
+++ b/src/main/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutor.java
@@ -117,9 +117,9 @@ public class DefaultQueryExecutor implements QueryExecutor {
     private final Lock writeLock = readWriteLock.writeLock();
     private final SchemaGenerator schemaGenerator = new SchemaGenerator();
 
-    private int queryMaxTokens;
+    private int maxQueryTokens;
 
-    private int queryMaxWhitespaceTokens;
+    private int maxWhitespaceTokens;
 
     @Reference
     private RankedSchemaProviders schemaProvider;
@@ -145,16 +145,18 @@ public class DefaultQueryExecutor implements QueryExecutor {
         int schemaCacheSize() default 128;
 
         @AttributeDefinition(
-                name = "Query Max Tokens",
-                description = "The number of GraphQL query tokens to parse. This is a safety measure to avoid denial of service attacks."
+                name = "Max Query Tokens",
+                description = "The number of GraphQL query tokens to parse. This is a safety measure to avoid denial of service attacks." +
+                        " Change ONLY if you know exactly what you are doing."
         )
-        int queryMaxTokens() default 15000;
+        int maxQueryTokens() default 15000;
 
         @AttributeDefinition(
-                name = "Query Max Whitespace Tokens",
-                description = "The number of GraphQL query whitespace tokens to parse. This is a safety measure to avoid denial of service attacks."
+                name = "Max Whitespace Tokens",
+                description = "The number of GraphQL query whitespace tokens to parse. This is a safety measure to avoid denial of service attacks." +
+                        " Change ONLY if you know exactly what you are doing."
         )
-        int queryMaxWhitespaceTokens() default 200000;
+        int maxWhitespaceTokens() default 200000;
     }
 
     private class ExecutionContext {
@@ -186,8 +188,8 @@ public class DefaultQueryExecutor implements QueryExecutor {
         if (schemaCacheSize < 0) {
             schemaCacheSize = 0;
         }
-        queryMaxTokens = config.queryMaxTokens();
-        queryMaxWhitespaceTokens = config.queryMaxWhitespaceTokens();
+        maxQueryTokens = config.maxQueryTokens();
+        maxWhitespaceTokens = config.maxWhitespaceTokens();
 
         resourceToHashMap = new LRUCache<>(schemaCacheSize);
         hashToSchemaMap = new LRUCache<>(schemaCacheSize);
@@ -420,8 +422,8 @@ public class DefaultQueryExecutor implements QueryExecutor {
     private Consumer<GraphQLContext.Builder> getGraphQLContextBuilder() {
         final ParserOptions opt = ParserOptions.getDefaultParserOptions().transform(builder -> {
             builder
-                .maxTokens(queryMaxTokens)
-                .maxWhitespaceTokens(queryMaxWhitespaceTokens)
+                .maxTokens(maxQueryTokens)
+                .maxWhitespaceTokens(maxWhitespaceTokens)
                 .build();
         });
         return builder -> builder.put(ParserOptions.class, opt);

--- a/src/main/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutor.java
+++ b/src/main/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutor.java
@@ -182,12 +182,12 @@ public class DefaultQueryExecutor implements QueryExecutor {
         }
 
         private Consumer<GraphQLContext.Builder> getGraphQLContextBuilder() {
-            final ParserOptions parserOptions = ParserOptions.getDefaultParserOptions().transform(builder -> {
+            final ParserOptions parserOptions = ParserOptions.getDefaultParserOptions().transform(builder ->
                 builder
                         .maxTokens(maxQueryTokens)
                         .maxWhitespaceTokens(maxWhitespaceTokens)
-                        .build();
-            });
+                        .build()
+            );
             return builder -> builder.put(ParserOptions.class, parserOptions);
         }
     }

--- a/src/test/java/org/apache/sling/graphql/core/engine/MaxQueryTokensTest.java
+++ b/src/test/java/org/apache/sling/graphql/core/engine/MaxQueryTokensTest.java
@@ -42,11 +42,11 @@ import static org.hamcrest.Matchers.containsString;
 
 /** Test the SLING-12198 configurable max tokens */
 @RunWith(Parameterized.class)
-public class QueryMaxTokensTest extends ResourceQueryTestBase {
-  private static final int DEFAULT_MAX_TOKENS = 15000;
+public class MaxQueryTokensTest extends ResourceQueryTestBase {
+  private static final int DEFAULT_MAX_QUERY_TOKENS = 15000;
   private static final String INVALID = "invalid ";
   private static final String WHITESPACE = " {\t";
-  private final Integer maxTokens;
+  private final Integer maxQueryTokens;
   private final Integer maxWhitespaceTokens;
   private final int nOk;
   private final int nTokensFailure;
@@ -55,15 +55,15 @@ public class QueryMaxTokensTest extends ResourceQueryTestBase {
   @Parameters(name = "{0}")
   public static Collection<Object[]> data() {
     final List<Object[]> result = new ArrayList<>();
-    result.add(new Object[] { "default values", null, null, DEFAULT_MAX_TOKENS - 1, DEFAULT_MAX_TOKENS, -1 });
+    result.add(new Object[] { "default values", null, null, DEFAULT_MAX_QUERY_TOKENS - 1, DEFAULT_MAX_QUERY_TOKENS, -1 });
     result.add(new Object[] { "same values", 100, 100, 99, 100, 100 });
     result.add(new Object[] { "more whitespace", 100, 200, 99, 100, 150 });
     return result;
   }
 
-  public QueryMaxTokensTest(String name, Integer maxTokens, Integer maxWhitespaceTokens, int nOk, int nTokensFailure,
+  public MaxQueryTokensTest(String name, Integer maxTokens, Integer maxWhitespaceTokens, int nOk, int nTokensFailure,
       int nWhitespaceFailure) {
-    this.maxTokens = maxTokens;
+    this.maxQueryTokens = maxTokens;
     this.maxWhitespaceTokens = maxWhitespaceTokens;
     this.nOk = nOk;
     this.nTokensFailure = nTokensFailure;
@@ -72,11 +72,11 @@ public class QueryMaxTokensTest extends ResourceQueryTestBase {
 
   protected Map<String, Object> getQueryExecutorProperties() {
     final Map<String, Object> props = new HashMap<>();
-    if (maxTokens != null) {
-      props.put("queryMaxTokens", maxTokens);
+    if (maxQueryTokens != null) {
+      props.put("maxQueryTokens", maxQueryTokens);
     }
     if (maxWhitespaceTokens != null) {
-      props.put("queryMaxWhitespaceTokens", maxWhitespaceTokens);
+      props.put("maxWhitespaceTokens", maxWhitespaceTokens);
     }
     return props;
   }

--- a/src/test/java/org/apache/sling/graphql/core/engine/QueryMaxTokensTest.java
+++ b/src/test/java/org/apache/sling/graphql/core/engine/QueryMaxTokensTest.java
@@ -1,0 +1,75 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Licensed to the Apache Software Foundation (ASF) under one
+ ~ or more contributor license agreements.  See the NOTICE file
+ ~ distributed with this work for additional information
+ ~ regarding copyright ownership.  The ASF licenses this file
+ ~ to you under the Apache License, Version 2.0 (the
+ ~ "License"); you may not use this file except in compliance
+ ~ with the License.  You may obtain a copy of the License at
+ ~
+ ~   http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package org.apache.sling.graphql.core.engine;
+
+import org.apache.sling.graphql.core.mocks.CharacterTypeResolver;
+import org.apache.sling.graphql.core.mocks.EchoDataFetcher;
+import org.apache.sling.graphql.core.mocks.TestUtil;
+import org.junit.Test;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.Matchers.equalTo;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.containsString;
+
+/** Test the SLING-12198 configurable max tokens */
+public class QueryMaxTokensTest extends ResourceQueryTestBase {
+    private static final int FAILING_TOKENS_COUNT = 15000;
+    private static final String INVALID = "invalid ";
+
+    static String repeat(String what, int howMany) {
+        final StringBuffer sb = new StringBuffer();
+        for(int i=0; i < howMany; i++) {
+            sb.append(what);
+        }
+        return sb.toString();
+    }
+
+    private void assertQueryFailure(String query, boolean isTooManyTokens) throws Exception {
+        final String json = queryJSON(query);
+        assertThat(json, hasJsonPath("$.errors[0].extensions.classification", is("InvalidSyntax")));
+        final String expected = isTooManyTokens ? "To prevent Denial Of Service attacks" : "Invalid syntax with offending token";
+        assertThat(json, hasJsonPath("$.errors[0].message", containsString(expected)));
+    }
+
+    protected void setupAdditionalServices() {
+        TestUtil.registerSlingTypeResolver(context.bundleContext(), "character/resolver", new CharacterTypeResolver());
+        TestUtil.registerSlingDataFetcher(context.bundleContext(), "echoNS/echo", new EchoDataFetcher(null));
+    }
+
+    @Test
+    public void verifyQueriesWork() throws Exception {
+        final String json = queryJSON("{ currentResource { path resourceType } }");
+        assertThat(json, hasJsonPath("$.data.currentResource"));
+        assertThat(json, hasJsonPath("$.data.currentResource.path", equalTo(resource.getPath())));
+        assertThat(json, hasJsonPath("$.data.currentResource.resourceType", equalTo(resource.getResourceType())));
+    }
+
+    @Test
+    public void numberOfTokensOk() throws Exception {
+        assertQueryFailure(repeat(INVALID, FAILING_TOKENS_COUNT - 1), false);
+    }
+
+    @Test
+    public void tooManyTokens() throws Exception {
+        assertQueryFailure(repeat(INVALID, FAILING_TOKENS_COUNT), true);
+    }
+}

--- a/src/test/java/org/apache/sling/graphql/core/engine/QueryMaxTokensTest.java
+++ b/src/test/java/org/apache/sling/graphql/core/engine/QueryMaxTokensTest.java
@@ -22,54 +22,108 @@ import org.apache.sling.graphql.core.mocks.CharacterTypeResolver;
 import org.apache.sling.graphql.core.mocks.EchoDataFetcher;
 import org.apache.sling.graphql.core.mocks.TestUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static org.hamcrest.Matchers.equalTo;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import static org.hamcrest.Matchers.containsString;
 
 /** Test the SLING-12198 configurable max tokens */
+@RunWith(Parameterized.class)
 public class QueryMaxTokensTest extends ResourceQueryTestBase {
-    private static final int FAILING_TOKENS_COUNT = 15000;
-    private static final String INVALID = "invalid ";
+  private static final int DEFAULT_MAX_TOKENS = 15000;
+  private static final String INVALID = "invalid ";
+  private static final String WHITESPACE = " {\t";
+  private final Integer maxTokens;
+  private final Integer maxWhitespaceTokens;
+  private final int nOk;
+  private final int nTokensFailure;
+  private final int nWhitespaceFailure;
 
-    static String repeat(String what, int howMany) {
-        final StringBuffer sb = new StringBuffer();
-        for(int i=0; i < howMany; i++) {
-            sb.append(what);
-        }
-        return sb.toString();
-    }
+  @Parameters(name = "{0}")
+  public static Collection<Object[]> data() {
+    final List<Object[]> result = new ArrayList<>();
+    result.add(new Object[] { "default values", null, null, DEFAULT_MAX_TOKENS - 1, DEFAULT_MAX_TOKENS, -1 });
+    result.add(new Object[] { "same values", 100, 100, 99, 100, 100 });
+    result.add(new Object[] { "more whitespace", 100, 200, 99, 100, 150 });
+    return result;
+  }
 
-    private void assertQueryFailure(String query, boolean isTooManyTokens) throws Exception {
-        final String json = queryJSON(query);
-        assertThat(json, hasJsonPath("$.errors[0].extensions.classification", is("InvalidSyntax")));
-        final String expected = isTooManyTokens ? "To prevent Denial Of Service attacks" : "Invalid syntax with offending token";
-        assertThat(json, hasJsonPath("$.errors[0].message", containsString(expected)));
-    }
+  public QueryMaxTokensTest(String name, Integer maxTokens, Integer maxWhitespaceTokens, int nOk, int nTokensFailure,
+      int nWhitespaceFailure) {
+    this.maxTokens = maxTokens;
+    this.maxWhitespaceTokens = maxWhitespaceTokens;
+    this.nOk = nOk;
+    this.nTokensFailure = nTokensFailure;
+    this.nWhitespaceFailure = nWhitespaceFailure;
+  }
 
-    protected void setupAdditionalServices() {
-        TestUtil.registerSlingTypeResolver(context.bundleContext(), "character/resolver", new CharacterTypeResolver());
-        TestUtil.registerSlingDataFetcher(context.bundleContext(), "echoNS/echo", new EchoDataFetcher(null));
+  protected Map<String, Object> getQueryExecutorProperties() {
+    final Map<String, Object> props = new HashMap<>();
+    if (maxTokens != null) {
+      props.put("queryMaxTokens", maxTokens);
     }
+    if (maxWhitespaceTokens != null) {
+      props.put("queryMaxWhitespaceTokens", maxWhitespaceTokens);
+    }
+    return props;
+  }
 
-    @Test
-    public void verifyQueriesWork() throws Exception {
-        final String json = queryJSON("{ currentResource { path resourceType } }");
-        assertThat(json, hasJsonPath("$.data.currentResource"));
-        assertThat(json, hasJsonPath("$.data.currentResource.path", equalTo(resource.getPath())));
-        assertThat(json, hasJsonPath("$.data.currentResource.resourceType", equalTo(resource.getResourceType())));
+  static String repeat(String what, int howMany) {
+    final StringBuffer sb = new StringBuffer();
+    for (int i = 0; i < howMany; i++) {
+      sb.append(what);
     }
+    return sb.toString();
+  }
 
-    @Test
-    public void numberOfTokensOk() throws Exception {
-        assertQueryFailure(repeat(INVALID, FAILING_TOKENS_COUNT - 1), false);
-    }
+  private void assertQueryFailure(String query, String expectedError) throws Exception {
+    final String json = queryJSON(query);
+    assertThat(json, hasJsonPath("$.errors[0].extensions.classification", is("InvalidSyntax")));
+    assertThat(json, hasJsonPath("$.errors[0].message", containsString(expectedError)));
+  }
 
-    @Test
-    public void tooManyTokens() throws Exception {
-        assertQueryFailure(repeat(INVALID, FAILING_TOKENS_COUNT), true);
+  protected void setupAdditionalServices() {
+    TestUtil.registerSlingTypeResolver(context.bundleContext(), "character/resolver", new CharacterTypeResolver());
+    TestUtil.registerSlingDataFetcher(context.bundleContext(), "echoNS/echo", new EchoDataFetcher(null));
+  }
+
+  @Test
+  public void verifyQueriesWork() throws Exception {
+    final String json = queryJSON("{ currentResource { path resourceType } }");
+    assertThat(json, hasJsonPath("$.data.currentResource"));
+    assertThat(json, hasJsonPath("$.data.currentResource.path", equalTo(resource.getPath())));
+    assertThat(json, hasJsonPath("$.data.currentResource.resourceType", equalTo(resource.getResourceType())));
+  }
+
+  @Test
+  public void numberOfTokensOk() throws Exception {
+    assertQueryFailure(repeat(INVALID, nOk), "Invalid syntax with offending token");
+  }
+
+  @Test
+  public void tooManyTokens() throws Exception {
+    assertQueryFailure(repeat(INVALID, nTokensFailure),
+        "'grammar' tokens have been presented. To prevent Denial Of Service");
+  }
+
+  @Test
+  public void tooManyWhitespaceTokens() throws Exception {
+    if (nWhitespaceFailure >= 0) {
+      assertQueryFailure(repeat(WHITESPACE, nWhitespaceFailure),
+          "'whitespace' tokens have been presented. To prevent Denial Of Service");
     }
+  }
 }

--- a/src/test/java/org/apache/sling/graphql/core/engine/ResourceQueryTestBase.java
+++ b/src/test/java/org/apache/sling/graphql/core/engine/ResourceQueryTestBase.java
@@ -70,7 +70,11 @@ public abstract class ResourceQueryTestBase {
         context.registerInjectActivateService(new SlingTypeResolverSelector());
         context.registerInjectActivateService(new SlingScalarsProvider());
         context.registerInjectActivateService(new RankedSchemaProviders());
-        context.registerInjectActivateService(new DefaultQueryExecutor());
+        context.registerInjectActivateService(new DefaultQueryExecutor(), getQueryExecutorProperties());
+    }
+
+    protected  Map<String, Object> getQueryExecutorProperties() {
+        return null;
     }
 
     protected String queryJSON(String stmt) throws Exception {


### PR DESCRIPTION
Added the possibility to configure GraphQL Parser options in the ExecutionInput#graphQLContext. This would allow to change the maxTokens and maxWhitespaceTokens limits from the OSGI configuration.

For the current need I've only added these two options and copied the rest from the default configuration, but we could add all possible values if that would make sense, but currently only these are causing issues in the query parsing. See https://issues.apache.org/jira/browse/SLING-12198