### PR TITLE
SLING-13302 - [GraphQL] Cache executable GraphQLSchema in DefaultQuer…

### DIFF
--- a/src/main/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutor.java
+++ b/src/main/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutor.java
@@ -549,9 +549,6 @@ public class DefaultQueryExecutor implements QueryExecutor {
         } catch (RuntimeException e) {
             created.completeExceptionally(e);
             throw e;
-        } catch (Exception e) {
-            created.completeExceptionally(e);
-            throw new SlingGraphQLException("Executable schema build failed", e);
         } finally {
             executableSchemaInFlight.remove(schemaHash, created);
         }

--- a/src/main/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutor.java
+++ b/src/main/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutor.java
@@ -511,78 +511,96 @@ public class DefaultQueryExecutor implements QueryExecutor {
     }
 
     /**
+     * Cap retries when scalar converters keep changing mid-build so we never return a known-stale schema
+     * and never spin forever under continuous churn.
+     */
+    private static final int MAX_EXECUTABLE_SCHEMA_BUILD_ATTEMPTS = 8;
+
+    /**
      * Returns an executable schema for the given SDL hash. When the executable schema cache is enabled,
      * concurrent callers for the same schema hash <em>and</em> scalar generation share a single in-flight build.
+     * If converters change during a build or while waiting, the call retries until the result matches the
+     * live generation or {@link #MAX_EXECUTABLE_SCHEMA_BUILD_ATTEMPTS} is exhausted.
      */
     GraphQLSchema getExecutableSchema(@NotNull String schemaHash, @NotNull TypeDefinitionRegistry typeRegistry) {
-        return getExecutableSchema(schemaHash, typeRegistry, true);
-    }
-
-    private GraphQLSchema getExecutableSchema(
-            @NotNull String schemaHash, @NotNull TypeDefinitionRegistry typeRegistry, boolean allowRetry) {
         if (!executableSchemaCacheEnabled) {
             return buildSchema(typeRegistry).schema;
         }
 
-        final long scalarGeneration = scalarsProvider.getScalarGeneration();
-        BuiltExecutableSchema cached = getCachedExecutableSchema(schemaHash, scalarGeneration);
-        if (cached != null) {
-            return cached.schema;
-        }
-
-        final String flightKey = schemaHash + ':' + scalarGeneration;
-        final CompletableFuture<BuiltExecutableSchema> created = new CompletableFuture<>();
-        final CompletableFuture<BuiltExecutableSchema> existing =
-                executableSchemaInFlight.putIfAbsent(flightKey, created);
-        if (existing != null) {
-            BuiltExecutableSchema built = awaitExecutableSchema(existing);
-            if (built.scalarGeneration == scalarsProvider.getScalarGeneration()) {
-                return built.schema;
+        for (int attempt = 0; attempt < MAX_EXECUTABLE_SCHEMA_BUILD_ATTEMPTS; attempt++) {
+            final long scalarGeneration = scalarsProvider.getScalarGeneration();
+            BuiltExecutableSchema cached = getCachedExecutableSchema(schemaHash, scalarGeneration);
+            if (cached != null) {
+                return cached.schema;
             }
-            // Joined a build that is stale relative to current converters — rebuild once.
-            if (allowRetry) {
-                return getExecutableSchema(schemaHash, typeRegistry, false);
-            }
-            return built.schema;
-        }
 
-        // Another builder may have finished between the cache miss and putIfAbsent winning.
-        cached = getCachedExecutableSchema(schemaHash, scalarsProvider.getScalarGeneration());
-        if (cached != null) {
-            created.complete(cached);
-            executableSchemaInFlight.remove(flightKey, created);
-            return cached.schema;
-        }
-
-        try {
-            final BuiltExecutableSchema built = buildSchema(typeRegistry);
-            final long currentGeneration = scalarsProvider.getScalarGeneration();
-            synchronized (executableSchemaCacheLock) {
-                if (built.scalarGeneration == currentGeneration) {
-                    hashToExecutableSchemaMap.put(schemaHash, built);
+            final String flightKey = schemaHash + ':' + scalarGeneration;
+            final CompletableFuture<BuiltExecutableSchema> created = new CompletableFuture<>();
+            final CompletableFuture<BuiltExecutableSchema> existing =
+                    executableSchemaInFlight.putIfAbsent(flightKey, created);
+            if (existing != null) {
+                BuiltExecutableSchema built = awaitExecutableSchema(existing);
+                if (built.scalarGeneration == scalarsProvider.getScalarGeneration()) {
+                    return built.schema;
                 }
+                // Joined a stale build — retry with the current generation.
+                continue;
             }
-            created.complete(built);
-            if (built.scalarGeneration != currentGeneration && allowRetry) {
-                return getExecutableSchema(schemaHash, typeRegistry, false);
+
+            // Another builder may have finished between the cache miss and putIfAbsent winning.
+            cached = getCachedExecutableSchema(schemaHash, scalarsProvider.getScalarGeneration());
+            if (cached != null) {
+                created.complete(cached);
+                executableSchemaInFlight.remove(flightKey, created);
+                return cached.schema;
             }
-            return built.schema;
-        } catch (Exception e) {
-            created.completeExceptionally(e);
-            if (e instanceof RuntimeException) {
-                throw (RuntimeException) e;
+
+            try {
+                final BuiltExecutableSchema built = buildSchema(typeRegistry);
+                publishExecutableSchema(schemaHash, built);
+                created.complete(built);
+                if (built.scalarGeneration == scalarsProvider.getScalarGeneration()) {
+                    return built.schema;
+                }
+                // Converters moved on during the build — retry; never return a known-stale schema.
+            } catch (Exception e) {
+                created.completeExceptionally(e);
+                if (e instanceof RuntimeException) {
+                    throw (RuntimeException) e;
+                }
+                throw new SlingGraphQLException("Executable schema build failed", e);
+            } catch (Error e) {
+                created.completeExceptionally(e);
+                throw e;
+            } finally {
+                executableSchemaInFlight.remove(flightKey, created);
             }
-            throw new SlingGraphQLException("Executable schema build failed", e);
-        } catch (Error e) {
-            created.completeExceptionally(e);
-            throw e;
-        } finally {
-            executableSchemaInFlight.remove(flightKey, created);
+        }
+
+        throw new SlingGraphQLException("Executable schema build did not stabilize after "
+                + MAX_EXECUTABLE_SCHEMA_BUILD_ATTEMPTS + " attempts (scalar converters changing)");
+    }
+
+    /**
+     * Publishes {@code built} only when its generation still matches the live converter generation under
+     * the cache lock, and never replaces a newer cached entry with an older one.
+     */
+    private void publishExecutableSchema(@NotNull String schemaHash, @NotNull BuiltExecutableSchema built) {
+        synchronized (executableSchemaCacheLock) {
+            if (built.scalarGeneration != scalarsProvider.getScalarGeneration()) {
+                return;
+            }
+            BuiltExecutableSchema existing = hashToExecutableSchemaMap.get(schemaHash);
+            if (existing == null || existing.scalarGeneration <= built.scalarGeneration) {
+                hashToExecutableSchemaMap.put(schemaHash, built);
+            }
         }
     }
 
     /**
-     * Returns a cached schema only when its scalar generation still matches {@code expectedGeneration}.
+     * Returns a cached schema only when its scalar generation matches {@code expectedGeneration}.
+     * Stale (older) entries may be evicted; a newer entry is left intact so a delayed old-generation
+     * caller cannot discard a valid fresher schema.
      */
     private BuiltExecutableSchema getCachedExecutableSchema(@NotNull String schemaHash, long expectedGeneration) {
         synchronized (executableSchemaCacheLock) {
@@ -590,11 +608,13 @@ public class DefaultQueryExecutor implements QueryExecutor {
             if (entry == null) {
                 return null;
             }
-            if (entry.scalarGeneration != expectedGeneration) {
-                hashToExecutableSchemaMap.remove(schemaHash, entry);
-                return null;
+            if (entry.scalarGeneration == expectedGeneration) {
+                return entry;
             }
-            return entry;
+            if (entry.scalarGeneration < expectedGeneration) {
+                hashToExecutableSchemaMap.remove(schemaHash, entry);
+            }
+            return null;
         }
     }
 

--- a/src/main/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutor.java
+++ b/src/main/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutor.java
@@ -69,6 +69,7 @@ import graphql.schema.idl.TypeRuntimeWiring;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.graphql.api.SchemaProvider;
 import org.apache.sling.graphql.api.SlingGraphQLException;
+import org.apache.sling.graphql.api.SlingScalarConverter;
 import org.apache.sling.graphql.api.engine.QueryExecutor;
 import org.apache.sling.graphql.api.engine.ValidationResult;
 import org.apache.sling.graphql.core.directives.Directives;
@@ -79,9 +80,12 @@ import org.apache.sling.graphql.core.util.LogSanitizer;
 import org.apache.sling.graphql.core.util.SlingGraphQLErrorHelper;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
 import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.Designate;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
@@ -230,12 +234,44 @@ public class DefaultQueryExecutor implements QueryExecutor {
         maxWhitespaceTokens = config.maxWhitespaceTokens();
         executableSchemaCacheEnabled = config.executableSchemaCacheEnabled() && schemaCacheSize > 0;
 
-        resourceToHashMap = new LRUCache<>(schemaCacheSize);
-        hashToSchemaMap = new LRUCache<>(schemaCacheSize);
-        hashToExecutableSchemaMap = new LRUCache<>(schemaCacheSize);
+        // Insertion-order for maps accessed under the shared RW lock (get mutates access-order maps).
+        resourceToHashMap = new BoundedCache<>(schemaCacheSize, false);
+        hashToSchemaMap = new BoundedCache<>(schemaCacheSize, false);
+        // True LRU for the executable schema map (all access is under executableSchemaCacheLock).
+        hashToExecutableSchemaMap = new BoundedCache<>(schemaCacheSize, true);
         executableSchemaInFlight.clear();
         ExecutableNormalizedOperationFactory.Options.setDefaultOptions(
                 ExecutableNormalizedOperationFactory.Options.defaultOptions().maxFieldsCount(config.maxFieldCount()));
+    }
+
+    /**
+     * Scalars are baked into cached executable schemas at build time. Clear that cache when converters change
+     * so subsequent requests rebuild with the current converter set.
+     */
+    @Reference(
+            service = SlingScalarConverter.class,
+            cardinality = ReferenceCardinality.MULTIPLE,
+            policy = ReferencePolicy.DYNAMIC)
+    private void bindSlingScalarConverter(
+            @SuppressWarnings("unused") ServiceReference<SlingScalarConverter<Object, Object>> reference,
+            @SuppressWarnings("unused") SlingScalarConverter<Object, Object> converter) {
+        clearExecutableSchemaCache();
+    }
+
+    @SuppressWarnings("unused")
+    private void unbindSlingScalarConverter(
+            ServiceReference<SlingScalarConverter<Object, Object>> reference,
+            SlingScalarConverter<Object, Object> converter) {
+        clearExecutableSchemaCache();
+    }
+
+    private void clearExecutableSchemaCache() {
+        if (hashToExecutableSchemaMap != null) {
+            synchronized (executableSchemaCacheLock) {
+                hashToExecutableSchemaMap.clear();
+            }
+        }
+        executableSchemaInFlight.clear();
     }
 
     @Override
@@ -419,10 +455,8 @@ public class DefaultQueryExecutor implements QueryExecutor {
             final String name = validateFetcherName(getDirectiveArgumentValue(d, FETCHER_NAME));
             final String options = getDirectiveArgumentValue(d, FETCHER_OPTIONS);
             final String source = getDirectiveArgumentValue(d, FETCHER_SOURCE);
-            // Presence check at wire time; the wrapper resolves the live OSGi service at fetch time.
-            if (dataFetcherSelector.getSlingFetcher(name) != null) {
-                result = new SlingDataFetcherWrapper<>(dataFetcherSelector, name, options, source);
-            }
+            // Always wire a wrapper so later OSGi registrations are visible to cached schemas.
+            result = new SlingDataFetcherWrapper<>(dataFetcherSelector, name, options, source);
         }
         return result;
     }
@@ -437,10 +471,8 @@ public class DefaultQueryExecutor implements QueryExecutor {
             final String name = validateResolverName(getDirectiveArgumentValue(d, RESOLVER_NAME));
             final String options = getDirectiveArgumentValue(d, RESOLVER_OPTIONS);
             final String source = getDirectiveArgumentValue(d, RESOLVER_SOURCE);
-            // Presence check at wire time; the wrapper resolves the live OSGi service at resolve time.
-            if (typeResolverSelector.getSlingTypeResolver(name) != null) {
-                resolver = new SlingTypeResolverWrapper(typeResolverSelector, name, options, source);
-            }
+            // Always wire a wrapper so later OSGi registrations are visible to cached schemas.
+            resolver = new SlingTypeResolverWrapper(typeResolverSelector, name, options, source);
         }
         return resolver;
     }
@@ -521,28 +553,23 @@ public class DefaultQueryExecutor implements QueryExecutor {
             return buildSchema(typeRegistry);
         }
 
-        synchronized (executableSchemaCacheLock) {
-            GraphQLSchema cached = hashToExecutableSchemaMap.get(schemaHash);
-            if (cached != null) {
-                return cached;
-            }
+        GraphQLSchema cached = getCachedExecutableSchema(schemaHash);
+        if (cached != null) {
+            return cached;
         }
 
         final CompletableFuture<GraphQLSchema> created = new CompletableFuture<>();
         final CompletableFuture<GraphQLSchema> existing = executableSchemaInFlight.putIfAbsent(schemaHash, created);
         if (existing != null) {
-            try {
-                return existing.get();
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new SlingGraphQLException("Interrupted while waiting for executable schema build", e);
-            } catch (ExecutionException e) {
-                Throwable cause = e.getCause() != null ? e.getCause() : e;
-                if (cause instanceof RuntimeException) {
-                    throw (RuntimeException) cause;
-                }
-                throw new SlingGraphQLException("Executable schema build failed", cause);
-            }
+            return awaitExecutableSchema(existing);
+        }
+
+        // Another builder may have finished between the cache miss and putIfAbsent winning.
+        cached = getCachedExecutableSchema(schemaHash);
+        if (cached != null) {
+            created.complete(cached);
+            executableSchemaInFlight.remove(schemaHash, created);
+            return cached;
         }
 
         try {
@@ -552,11 +579,41 @@ public class DefaultQueryExecutor implements QueryExecutor {
             }
             created.complete(built);
             return built;
-        } catch (RuntimeException e) {
-            created.completeExceptionally(e);
-            throw e;
+        } catch (Throwable t) {
+            created.completeExceptionally(t);
+            if (t instanceof Error) {
+                throw (Error) t;
+            }
+            if (t instanceof RuntimeException) {
+                throw (RuntimeException) t;
+            }
+            throw new SlingGraphQLException("Executable schema build failed", t);
         } finally {
             executableSchemaInFlight.remove(schemaHash, created);
+        }
+    }
+
+    private GraphQLSchema getCachedExecutableSchema(@NotNull String schemaHash) {
+        synchronized (executableSchemaCacheLock) {
+            return hashToExecutableSchemaMap.get(schemaHash);
+        }
+    }
+
+    private static GraphQLSchema awaitExecutableSchema(CompletableFuture<GraphQLSchema> future) {
+        try {
+            return future.get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new SlingGraphQLException("Interrupted while waiting for executable schema build", e);
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            if (cause instanceof Error) {
+                throw (Error) cause;
+            }
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            }
+            throw new SlingGraphQLException("Executable schema build failed", cause);
         }
     }
 
@@ -616,11 +673,16 @@ public class DefaultQueryExecutor implements QueryExecutor {
         }
     }
 
-    private static class LRUCache<T> extends LinkedHashMap<String, T> {
+    /**
+     * Bounded {@link LinkedHashMap}. When {@code accessOrder} is true this is a true LRU (safe only if all
+     * access is externally synchronized). When false, eviction is insertion-order / FIFO.
+     */
+    private static class BoundedCache<T> extends LinkedHashMap<String, T> {
 
         private final int capacity;
 
-        public LRUCache(int capacity) {
+        public BoundedCache(int capacity, boolean accessOrder) {
+            super(16, 0.75f, accessOrder);
             this.capacity = capacity;
         }
 
@@ -639,8 +701,8 @@ public class DefaultQueryExecutor implements QueryExecutor {
             if (o == this) {
                 return true;
             }
-            if (o instanceof LRUCache) {
-                LRUCache<T> other = (LRUCache<T>) o;
+            if (o instanceof BoundedCache) {
+                BoundedCache<T> other = (BoundedCache<T>) o;
                 return super.equals(o) && capacity == other.capacity;
             }
             return false;

--- a/src/main/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutor.java
+++ b/src/main/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutor.java
@@ -69,7 +69,6 @@ import graphql.schema.idl.TypeRuntimeWiring;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.graphql.api.SchemaProvider;
 import org.apache.sling.graphql.api.SlingGraphQLException;
-import org.apache.sling.graphql.api.SlingScalarConverter;
 import org.apache.sling.graphql.api.engine.QueryExecutor;
 import org.apache.sling.graphql.api.engine.ValidationResult;
 import org.apache.sling.graphql.core.directives.Directives;
@@ -80,12 +79,9 @@ import org.apache.sling.graphql.core.util.LogSanitizer;
 import org.apache.sling.graphql.core.util.SlingGraphQLErrorHelper;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicy;
 import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.Designate;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
@@ -242,36 +238,6 @@ public class DefaultQueryExecutor implements QueryExecutor {
         executableSchemaInFlight.clear();
         ExecutableNormalizedOperationFactory.Options.setDefaultOptions(
                 ExecutableNormalizedOperationFactory.Options.defaultOptions().maxFieldsCount(config.maxFieldCount()));
-    }
-
-    /**
-     * Scalars are baked into cached executable schemas at build time. Clear that cache when converters change
-     * so subsequent requests rebuild with the current converter set.
-     */
-    @Reference(
-            service = SlingScalarConverter.class,
-            cardinality = ReferenceCardinality.MULTIPLE,
-            policy = ReferencePolicy.DYNAMIC)
-    private void bindSlingScalarConverter(
-            @SuppressWarnings("unused") ServiceReference<SlingScalarConverter<Object, Object>> reference,
-            @SuppressWarnings("unused") SlingScalarConverter<Object, Object> converter) {
-        clearExecutableSchemaCache();
-    }
-
-    @SuppressWarnings("unused")
-    private void unbindSlingScalarConverter(
-            ServiceReference<SlingScalarConverter<Object, Object>> reference,
-            SlingScalarConverter<Object, Object> converter) {
-        clearExecutableSchemaCache();
-    }
-
-    private void clearExecutableSchemaCache() {
-        if (hashToExecutableSchemaMap != null) {
-            synchronized (executableSchemaCacheLock) {
-                hashToExecutableSchemaMap.clear();
-            }
-        }
-        executableSchemaInFlight.clear();
     }
 
     @Override
@@ -550,7 +516,7 @@ public class DefaultQueryExecutor implements QueryExecutor {
      */
     GraphQLSchema getExecutableSchema(@NotNull String schemaHash, @NotNull TypeDefinitionRegistry typeRegistry) {
         if (!executableSchemaCacheEnabled) {
-            return buildSchema(typeRegistry);
+            return buildSchema(typeRegistry).schema;
         }
 
         GraphQLSchema cached = getCachedExecutableSchema(schemaHash);
@@ -573,21 +539,24 @@ public class DefaultQueryExecutor implements QueryExecutor {
         }
 
         try {
-            final GraphQLSchema built = buildSchema(typeRegistry);
+            final BuiltExecutableSchema built = buildSchema(typeRegistry);
             synchronized (executableSchemaCacheLock) {
-                hashToExecutableSchemaMap.put(schemaHash, built);
+                // Only cache if scalar converters are unchanged since the snapshot used for wiring.
+                if (built.scalarGeneration == scalarsProvider.getScalarGeneration()) {
+                    hashToExecutableSchemaMap.put(schemaHash, built.schema);
+                }
             }
-            created.complete(built);
-            return built;
-        } catch (Throwable t) {
-            created.completeExceptionally(t);
-            if (t instanceof Error) {
-                throw (Error) t;
+            created.complete(built.schema);
+            return built.schema;
+        } catch (Exception e) {
+            created.completeExceptionally(e);
+            if (e instanceof RuntimeException) {
+                throw (RuntimeException) e;
             }
-            if (t instanceof RuntimeException) {
-                throw (RuntimeException) t;
-            }
-            throw new SlingGraphQLException("Executable schema build failed", t);
+            throw new SlingGraphQLException("Executable schema build failed", e);
+        } catch (Error e) {
+            created.completeExceptionally(e);
+            throw e;
         } finally {
             executableSchemaInFlight.remove(schemaHash, created);
         }
@@ -617,10 +586,21 @@ public class DefaultQueryExecutor implements QueryExecutor {
         }
     }
 
-    private GraphQLSchema buildSchema(@NotNull TypeDefinitionRegistry typeRegistry) {
-        Iterable<GraphQLScalarType> scalars = scalarsProvider.getCustomScalars(typeRegistry.scalars());
-        RuntimeWiring runtimeWiring = buildWiring(typeRegistry, scalars);
-        return schemaGenerator.makeExecutableSchema(typeRegistry, runtimeWiring);
+    private BuiltExecutableSchema buildSchema(@NotNull TypeDefinitionRegistry typeRegistry) {
+        SlingScalarsProvider.CustomScalars customScalars = scalarsProvider.getCustomScalars(typeRegistry.scalars());
+        RuntimeWiring runtimeWiring = buildWiring(typeRegistry, customScalars.getScalars());
+        GraphQLSchema schema = schemaGenerator.makeExecutableSchema(typeRegistry, runtimeWiring);
+        return new BuiltExecutableSchema(schema, customScalars.getGeneration());
+    }
+
+    private static final class BuiltExecutableSchema {
+        private final GraphQLSchema schema;
+        private final long scalarGeneration;
+
+        private BuiltExecutableSchema(GraphQLSchema schema, long scalarGeneration) {
+            this.schema = schema;
+            this.scalarGeneration = scalarGeneration;
+        }
     }
 
     private String getCacheKey(@NotNull Resource resource, @NotNull String[] selectors) {

--- a/src/main/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutor.java
+++ b/src/main/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutor.java
@@ -114,8 +114,8 @@ public class DefaultQueryExecutor implements QueryExecutor {
 
     private Map<String, String> resourceToHashMap;
     private Map<String, TypeDefinitionRegistry> hashToSchemaMap;
-    private Map<String, GraphQLSchema> hashToExecutableSchemaMap;
-    private final ConcurrentHashMap<String, CompletableFuture<GraphQLSchema>> executableSchemaInFlight =
+    private Map<String, BuiltExecutableSchema> hashToExecutableSchemaMap;
+    private final ConcurrentHashMap<String, CompletableFuture<BuiltExecutableSchema>> executableSchemaInFlight =
             new ConcurrentHashMap<>();
     private final Object executableSchemaCacheLock = new Object();
     private final ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
@@ -512,41 +512,60 @@ public class DefaultQueryExecutor implements QueryExecutor {
 
     /**
      * Returns an executable schema for the given SDL hash. When the executable schema cache is enabled,
-     * concurrent callers for the same hash share a single in-flight build (per-key single-flight).
+     * concurrent callers for the same schema hash <em>and</em> scalar generation share a single in-flight build.
      */
     GraphQLSchema getExecutableSchema(@NotNull String schemaHash, @NotNull TypeDefinitionRegistry typeRegistry) {
+        return getExecutableSchema(schemaHash, typeRegistry, true);
+    }
+
+    private GraphQLSchema getExecutableSchema(
+            @NotNull String schemaHash, @NotNull TypeDefinitionRegistry typeRegistry, boolean allowRetry) {
         if (!executableSchemaCacheEnabled) {
             return buildSchema(typeRegistry).schema;
         }
 
-        GraphQLSchema cached = getCachedExecutableSchema(schemaHash);
+        final long scalarGeneration = scalarsProvider.getScalarGeneration();
+        BuiltExecutableSchema cached = getCachedExecutableSchema(schemaHash, scalarGeneration);
         if (cached != null) {
-            return cached;
+            return cached.schema;
         }
 
-        final CompletableFuture<GraphQLSchema> created = new CompletableFuture<>();
-        final CompletableFuture<GraphQLSchema> existing = executableSchemaInFlight.putIfAbsent(schemaHash, created);
+        final String flightKey = schemaHash + ':' + scalarGeneration;
+        final CompletableFuture<BuiltExecutableSchema> created = new CompletableFuture<>();
+        final CompletableFuture<BuiltExecutableSchema> existing =
+                executableSchemaInFlight.putIfAbsent(flightKey, created);
         if (existing != null) {
-            return awaitExecutableSchema(existing);
+            BuiltExecutableSchema built = awaitExecutableSchema(existing);
+            if (built.scalarGeneration == scalarsProvider.getScalarGeneration()) {
+                return built.schema;
+            }
+            // Joined a build that is stale relative to current converters — rebuild once.
+            if (allowRetry) {
+                return getExecutableSchema(schemaHash, typeRegistry, false);
+            }
+            return built.schema;
         }
 
         // Another builder may have finished between the cache miss and putIfAbsent winning.
-        cached = getCachedExecutableSchema(schemaHash);
+        cached = getCachedExecutableSchema(schemaHash, scalarsProvider.getScalarGeneration());
         if (cached != null) {
             created.complete(cached);
-            executableSchemaInFlight.remove(schemaHash, created);
-            return cached;
+            executableSchemaInFlight.remove(flightKey, created);
+            return cached.schema;
         }
 
         try {
             final BuiltExecutableSchema built = buildSchema(typeRegistry);
+            final long currentGeneration = scalarsProvider.getScalarGeneration();
             synchronized (executableSchemaCacheLock) {
-                // Only cache if scalar converters are unchanged since the snapshot used for wiring.
-                if (built.scalarGeneration == scalarsProvider.getScalarGeneration()) {
-                    hashToExecutableSchemaMap.put(schemaHash, built.schema);
+                if (built.scalarGeneration == currentGeneration) {
+                    hashToExecutableSchemaMap.put(schemaHash, built);
                 }
             }
-            created.complete(built.schema);
+            created.complete(built);
+            if (built.scalarGeneration != currentGeneration && allowRetry) {
+                return getExecutableSchema(schemaHash, typeRegistry, false);
+            }
             return built.schema;
         } catch (Exception e) {
             created.completeExceptionally(e);
@@ -558,17 +577,28 @@ public class DefaultQueryExecutor implements QueryExecutor {
             created.completeExceptionally(e);
             throw e;
         } finally {
-            executableSchemaInFlight.remove(schemaHash, created);
+            executableSchemaInFlight.remove(flightKey, created);
         }
     }
 
-    private GraphQLSchema getCachedExecutableSchema(@NotNull String schemaHash) {
+    /**
+     * Returns a cached schema only when its scalar generation still matches {@code expectedGeneration}.
+     */
+    private BuiltExecutableSchema getCachedExecutableSchema(@NotNull String schemaHash, long expectedGeneration) {
         synchronized (executableSchemaCacheLock) {
-            return hashToExecutableSchemaMap.get(schemaHash);
+            BuiltExecutableSchema entry = hashToExecutableSchemaMap.get(schemaHash);
+            if (entry == null) {
+                return null;
+            }
+            if (entry.scalarGeneration != expectedGeneration) {
+                hashToExecutableSchemaMap.remove(schemaHash, entry);
+                return null;
+            }
+            return entry;
         }
     }
 
-    private static GraphQLSchema awaitExecutableSchema(CompletableFuture<GraphQLSchema> future) {
+    private static BuiltExecutableSchema awaitExecutableSchema(CompletableFuture<BuiltExecutableSchema> future) {
         try {
             return future.get();
         } catch (InterruptedException e) {

--- a/src/main/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutor.java
+++ b/src/main/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutor.java
@@ -534,51 +534,77 @@ public class DefaultQueryExecutor implements QueryExecutor {
                 return cached.schema;
             }
 
-            final String flightKey = schemaHash + ':' + scalarGeneration;
-            final CompletableFuture<BuiltExecutableSchema> created = new CompletableFuture<>();
-            final CompletableFuture<BuiltExecutableSchema> existing =
-                    executableSchemaInFlight.putIfAbsent(flightKey, created);
-            if (existing != null) {
-                BuiltExecutableSchema built = awaitExecutableSchema(existing);
-                if (built.scalarGeneration == scalarsProvider.getScalarGeneration()) {
-                    return built.schema;
-                }
-                // Joined a stale build — retry with the current generation.
-                continue;
+            GraphQLSchema schema = joinOrBuildExecutableSchema(schemaHash, typeRegistry, scalarGeneration);
+            if (schema != null) {
+                return schema;
             }
-
-            // Another builder may have finished between the cache miss and putIfAbsent winning.
-            cached = getCachedExecutableSchema(schemaHash, scalarsProvider.getScalarGeneration());
-            if (cached != null) {
-                created.complete(cached);
-                executableSchemaInFlight.remove(flightKey, created);
-                return cached.schema;
-            }
-
-            try {
-                final BuiltExecutableSchema built = buildSchema(typeRegistry);
-                publishExecutableSchema(schemaHash, built);
-                created.complete(built);
-                if (built.scalarGeneration == scalarsProvider.getScalarGeneration()) {
-                    return built.schema;
-                }
-                // Converters moved on during the build — retry; never return a known-stale schema.
-            } catch (Exception e) {
-                created.completeExceptionally(e);
-                if (e instanceof RuntimeException) {
-                    throw (RuntimeException) e;
-                }
-                throw new SlingGraphQLException("Executable schema build failed", e);
-            } catch (Error e) {
-                created.completeExceptionally(e);
-                throw e;
-            } finally {
-                executableSchemaInFlight.remove(flightKey, created);
-            }
+            // Result was stale relative to live converters — retry.
         }
 
         throw new SlingGraphQLException("Executable schema build did not stabilize after "
                 + MAX_EXECUTABLE_SCHEMA_BUILD_ATTEMPTS + " attempts (scalar converters changing)");
+    }
+
+    /**
+     * Joins an in-flight build or builds the schema for {@code scalarGeneration}.
+     *
+     * @return the schema when it matches the live scalar generation; {@code null} to signal a retry
+     */
+    private GraphQLSchema joinOrBuildExecutableSchema(
+            @NotNull String schemaHash, @NotNull TypeDefinitionRegistry typeRegistry, long scalarGeneration) {
+        final String flightKey = schemaHash + ':' + scalarGeneration;
+        final CompletableFuture<BuiltExecutableSchema> created = new CompletableFuture<>();
+        final CompletableFuture<BuiltExecutableSchema> existing =
+                executableSchemaInFlight.putIfAbsent(flightKey, created);
+        if (existing != null) {
+            return schemaIfCurrentGeneration(awaitExecutableSchema(existing));
+        }
+
+        // Another builder may have finished between the cache miss and putIfAbsent winning.
+        BuiltExecutableSchema cached = getCachedExecutableSchema(schemaHash, scalarsProvider.getScalarGeneration());
+        if (cached != null) {
+            created.complete(cached);
+            executableSchemaInFlight.remove(flightKey, created);
+            return cached.schema;
+        }
+
+        return buildPublishAndComplete(schemaHash, typeRegistry, flightKey, created);
+    }
+
+    /**
+     * Builds, optionally publishes, and completes {@code created}. Returns the schema when generation is
+     * still current, otherwise {@code null} so the caller can retry. Does not catch {@link Error}; if the
+     * builder aborts with an Error, {@code finally} still completes the future so waiters do not hang.
+     */
+    private GraphQLSchema buildPublishAndComplete(
+            @NotNull String schemaHash,
+            @NotNull TypeDefinitionRegistry typeRegistry,
+            @NotNull String flightKey,
+            @NotNull CompletableFuture<BuiltExecutableSchema> created) {
+        try {
+            final BuiltExecutableSchema built = buildSchema(typeRegistry);
+            publishExecutableSchema(schemaHash, built);
+            created.complete(built);
+            return schemaIfCurrentGeneration(built);
+        } catch (Exception e) {
+            created.completeExceptionally(e);
+            if (e instanceof RuntimeException) {
+                throw (RuntimeException) e;
+            }
+            throw new SlingGraphQLException("Executable schema build failed", e);
+        } finally {
+            if (!created.isDone()) {
+                created.completeExceptionally(new IllegalStateException("Executable schema build aborted"));
+            }
+            executableSchemaInFlight.remove(flightKey, created);
+        }
+    }
+
+    private GraphQLSchema schemaIfCurrentGeneration(@NotNull BuiltExecutableSchema built) {
+        if (built.scalarGeneration == scalarsProvider.getScalarGeneration()) {
+            return built.schema;
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutor.java
+++ b/src/main/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutor.java
@@ -65,6 +65,7 @@ import graphql.schema.idl.RuntimeWiring;
 import graphql.schema.idl.SchemaGenerator;
 import graphql.schema.idl.SchemaParser;
 import graphql.schema.idl.TypeDefinitionRegistry;
+import graphql.schema.idl.TypeRuntimeWiring;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.graphql.api.SchemaProvider;
 import org.apache.sling.graphql.api.SlingGraphQLException;
@@ -337,19 +338,7 @@ public class DefaultQueryExecutor implements QueryExecutor {
         RuntimeWiring.Builder builder = RuntimeWiring.newRuntimeWiring();
         for (ObjectTypeDefinition type : types) {
             builder.type(type.getName(), typeWiring -> {
-                for (FieldDefinition field : type.getFieldDefinitions()) {
-                    try {
-                        DataFetcher<Object> fetcher = getDataFetcher(field);
-                        if (fetcher != null) {
-                            typeWiring.dataFetcher(field.getName(), fetcher);
-                        }
-                    } catch (SlingGraphQLException e) {
-                        throw e;
-                    } catch (Exception e) {
-                        throw new SlingGraphQLException("Exception while building wiring.", e);
-                    }
-                }
-                handleConnectionTypes(type, typeRegistry);
+                wireObjectTypeFields(typeWiring, type, typeRegistry);
                 return typeWiring;
             });
         }
@@ -363,6 +352,23 @@ public class DefaultQueryExecutor implements QueryExecutor {
             wireTypeResolver(builder, type);
         }
         return builder.build();
+    }
+
+    private void wireObjectTypeFields(
+            TypeRuntimeWiring.Builder typeWiring, ObjectTypeDefinition type, TypeDefinitionRegistry typeRegistry) {
+        for (FieldDefinition field : type.getFieldDefinitions()) {
+            try {
+                DataFetcher<Object> fetcher = getDataFetcher(field);
+                if (fetcher != null) {
+                    typeWiring.dataFetcher(field.getName(), fetcher);
+                }
+            } catch (SlingGraphQLException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new SlingGraphQLException("Exception while building wiring.", e);
+            }
+        }
+        handleConnectionTypes(type, typeRegistry);
     }
 
     private <T extends TypeDefinition<T>> void wireTypeResolver(RuntimeWiring.Builder builder, TypeDefinition<T> type) {

--- a/src/main/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutor.java
+++ b/src/main/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutor.java
@@ -26,6 +26,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -64,9 +67,7 @@ import graphql.schema.idl.SchemaParser;
 import graphql.schema.idl.TypeDefinitionRegistry;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.graphql.api.SchemaProvider;
-import org.apache.sling.graphql.api.SlingDataFetcher;
 import org.apache.sling.graphql.api.SlingGraphQLException;
-import org.apache.sling.graphql.api.SlingTypeResolver;
 import org.apache.sling.graphql.api.engine.QueryExecutor;
 import org.apache.sling.graphql.api.engine.ValidationResult;
 import org.apache.sling.graphql.core.directives.Directives;
@@ -112,6 +113,10 @@ public class DefaultQueryExecutor implements QueryExecutor {
 
     private Map<String, String> resourceToHashMap;
     private Map<String, TypeDefinitionRegistry> hashToSchemaMap;
+    private Map<String, GraphQLSchema> hashToExecutableSchemaMap;
+    private final ConcurrentHashMap<String, CompletableFuture<GraphQLSchema>> executableSchemaInFlight =
+            new ConcurrentHashMap<>();
+    private final Object executableSchemaCacheLock = new Object();
     private final ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
     private final Lock readLock = readWriteLock.readLock();
     private final Lock writeLock = readWriteLock.writeLock();
@@ -120,6 +125,8 @@ public class DefaultQueryExecutor implements QueryExecutor {
     private int maxQueryTokens;
 
     private int maxWhitespaceTokens;
+
+    private boolean executableSchemaCacheEnabled;
 
     @Reference
     private RankedSchemaProviders schemaProvider;
@@ -139,8 +146,17 @@ public class DefaultQueryExecutor implements QueryExecutor {
                 name = "Schema Cache Size",
                 description =
                         "The number of compiled GraphQL schemas to cache. Since a schema normally doesn't change often, they can be"
-                                + " cached and reused, rather than parsed by the engine all the time. The cache is a LRU and will store up to this number of schemas.")
+                                + " cached and reused, rather than parsed by the engine all the time. The cache is a LRU and will store up to this number of schemas."
+                                + " Also bounds the optional executable schema cache when that is enabled.")
         int schemaCacheSize() default 128;
+
+        @AttributeDefinition(
+                name = "Enable Executable Schema Cache",
+                description =
+                        "When enabled, caches the executable GraphQLSchema (makeExecutableSchema result) keyed by SDL hash,"
+                                + " with per-key single-flight so concurrent requests for the same schema share one build."
+                                + " Disable to restore the previous behaviour of rebuilding the executable schema on every request.")
+        boolean executableSchemaCacheEnabled() default false;
 
         @AttributeDefinition(
                 name = "Max Query Tokens",
@@ -181,23 +197,25 @@ public class DefaultQueryExecutor implements QueryExecutor {
                         queryResource, Arrays.toString(selectors)));
             }
             LOGGER.debug("Resource {} maps to GQL schema {}", queryResource.getPath(), schemaSdl);
+            final String schemaHash = SHA256Hasher.getHash(schemaSdl);
             final TypeDefinitionRegistry typeDefinitionRegistry =
                     getTypeDefinitionRegistry(schemaSdl, queryResource, selectors);
-            schema = buildSchema(typeDefinitionRegistry, queryResource);
+            schema = getExecutableSchema(schemaHash, typeDefinitionRegistry);
             input = ExecutionInput.newExecutionInput()
                     .query(query)
                     .variables(variables)
-                    .graphQLContext(getGraphQLContextBuilder())
+                    .graphQLContext(getGraphQLContextBuilder(queryResource))
                     .build();
         }
 
-        private Consumer<GraphQLContext.Builder> getGraphQLContextBuilder() {
+        private Consumer<GraphQLContext.Builder> getGraphQLContextBuilder(@NotNull Resource queryResource) {
             final ParserOptions parserOptions = ParserOptions.getDefaultParserOptions()
                     .transform(builder -> builder.maxTokens(maxQueryTokens)
                             .maxWhitespaceTokens(maxWhitespaceTokens)
                             .build());
             return builder -> builder.put(ParserOptions.class, parserOptions)
-                    .put(InputInterceptor.class, LegacyCoercingInputInterceptor.migratesValues());
+                    .put(InputInterceptor.class, LegacyCoercingInputInterceptor.migratesValues())
+                    .put(Resource.class, queryResource);
         }
     }
 
@@ -209,9 +227,12 @@ public class DefaultQueryExecutor implements QueryExecutor {
         }
         maxQueryTokens = config.maxQueryTokens();
         maxWhitespaceTokens = config.maxWhitespaceTokens();
+        executableSchemaCacheEnabled = config.executableSchemaCacheEnabled() && schemaCacheSize > 0;
 
         resourceToHashMap = new LRUCache<>(schemaCacheSize);
         hashToSchemaMap = new LRUCache<>(schemaCacheSize);
+        hashToExecutableSchemaMap = new LRUCache<>(schemaCacheSize);
+        executableSchemaInFlight.clear();
         ExecutableNormalizedOperationFactory.Options.setDefaultOptions(
                 ExecutableNormalizedOperationFactory.Options.defaultOptions().maxFieldsCount(config.maxFieldCount()));
     }
@@ -311,15 +332,14 @@ public class DefaultQueryExecutor implements QueryExecutor {
         }
     }
 
-    private RuntimeWiring buildWiring(
-            TypeDefinitionRegistry typeRegistry, Iterable<GraphQLScalarType> scalars, Resource r) {
+    private RuntimeWiring buildWiring(TypeDefinitionRegistry typeRegistry, Iterable<GraphQLScalarType> scalars) {
         List<ObjectTypeDefinition> types = typeRegistry.getTypes(ObjectTypeDefinition.class);
         RuntimeWiring.Builder builder = RuntimeWiring.newRuntimeWiring();
         for (ObjectTypeDefinition type : types) {
             builder.type(type.getName(), typeWiring -> {
                 for (FieldDefinition field : type.getFieldDefinitions()) {
                     try {
-                        DataFetcher<Object> fetcher = getDataFetcher(field, r);
+                        DataFetcher<Object> fetcher = getDataFetcher(field);
                         if (fetcher != null) {
                             typeWiring.dataFetcher(field.getName(), fetcher);
                         }
@@ -336,19 +356,18 @@ public class DefaultQueryExecutor implements QueryExecutor {
         scalars.forEach(builder::scalar);
         List<UnionTypeDefinition> unionTypes = typeRegistry.getTypes(UnionTypeDefinition.class);
         for (UnionTypeDefinition type : unionTypes) {
-            wireTypeResolver(builder, type, r);
+            wireTypeResolver(builder, type);
         }
         List<InterfaceTypeDefinition> interfaceTypes = typeRegistry.getTypes(InterfaceTypeDefinition.class);
         for (InterfaceTypeDefinition type : interfaceTypes) {
-            wireTypeResolver(builder, type, r);
+            wireTypeResolver(builder, type);
         }
         return builder.build();
     }
 
-    private <T extends TypeDefinition<T>> void wireTypeResolver(
-            RuntimeWiring.Builder builder, TypeDefinition<T> type, Resource r) {
+    private <T extends TypeDefinition<T>> void wireTypeResolver(RuntimeWiring.Builder builder, TypeDefinition<T> type) {
         try {
-            TypeResolver resolver = getTypeResolver(type, r);
+            TypeResolver resolver = getTypeResolver(type);
             if (resolver != null) {
                 builder.type(type.getName(), typeWriting -> typeWriting.typeResolver(resolver));
             }
@@ -384,7 +403,7 @@ public class DefaultQueryExecutor implements QueryExecutor {
                 name, SlingTypeResolverSelector.RESOLVER_NAME_PATTERN));
     }
 
-    private DataFetcher<Object> getDataFetcher(FieldDefinition field, Resource currentResource) {
+    private DataFetcher<Object> getDataFetcher(FieldDefinition field) {
         DataFetcher<Object> result = null;
         final Directive d = field.getDirectives().stream()
                 .filter(i -> FETCHER_DIRECTIVE.equals(i.getName()))
@@ -394,16 +413,15 @@ public class DefaultQueryExecutor implements QueryExecutor {
             final String name = validateFetcherName(getDirectiveArgumentValue(d, FETCHER_NAME));
             final String options = getDirectiveArgumentValue(d, FETCHER_OPTIONS);
             final String source = getDirectiveArgumentValue(d, FETCHER_SOURCE);
-            SlingDataFetcher<Object> f = dataFetcherSelector.getSlingFetcher(name);
-            if (f != null) {
-                result = new SlingDataFetcherWrapper<>(f, currentResource, options, source);
+            // Presence check at wire time; the wrapper resolves the live OSGi service at fetch time.
+            if (dataFetcherSelector.getSlingFetcher(name) != null) {
+                result = new SlingDataFetcherWrapper<>(dataFetcherSelector, name, options, source);
             }
         }
         return result;
     }
 
-    private <T extends TypeDefinition<T>> TypeResolver getTypeResolver(
-            TypeDefinition<T> typeDefinition, Resource currentResource) {
+    private <T extends TypeDefinition<T>> TypeResolver getTypeResolver(TypeDefinition<T> typeDefinition) {
         TypeResolver resolver = null;
         final Directive d = typeDefinition.getDirectives().stream()
                 .filter(i -> RESOLVER_DIRECTIVE.equals(i.getName()))
@@ -413,9 +431,9 @@ public class DefaultQueryExecutor implements QueryExecutor {
             final String name = validateResolverName(getDirectiveArgumentValue(d, RESOLVER_NAME));
             final String options = getDirectiveArgumentValue(d, RESOLVER_OPTIONS);
             final String source = getDirectiveArgumentValue(d, RESOLVER_SOURCE);
-            SlingTypeResolver<Object> r = typeResolverSelector.getSlingTypeResolver(name);
-            if (r != null) {
-                resolver = new SlingTypeResolverWrapper(r, currentResource, options, source);
+            // Presence check at wire time; the wrapper resolves the live OSGi service at resolve time.
+            if (typeResolverSelector.getSlingTypeResolver(name) != null) {
+                resolver = new SlingTypeResolverWrapper(typeResolverSelector, name, options, source);
             }
         }
         return resolver;
@@ -442,11 +460,13 @@ public class DefaultQueryExecutor implements QueryExecutor {
         readLock.lock();
         String newHash = SHA256Hasher.getHash(sdl);
         /*
-        Since the SchemaProviders that generate the SDL can dynamically change, but also since the resource is passed to the RuntimeWiring,
-        there's a two stage cache:
+        Since the SchemaProviders that generate the SDL can dynamically change, there's a two stage cache for parsed schemas:
 
         1. a mapping between the resource, selectors and the SDL's hash
-        2. a mapping between the hash and the compiled GraphQL schema
+        2. a mapping between the hash and the TypeDefinitionRegistry
+
+        The request Resource is no longer baked into RuntimeWiring; it is supplied via GraphQLContext per execution.
+        An optional third cache (hash → GraphQLSchema) is controlled by executableSchemaCacheEnabled.
          */
         String resourceToHashMapKey = getCacheKey(currentResource, selectors);
         String oldHash = resourceToHashMap.get(resourceToHashMapKey);
@@ -486,9 +506,60 @@ public class DefaultQueryExecutor implements QueryExecutor {
         }
     }
 
-    private GraphQLSchema buildSchema(@NotNull TypeDefinitionRegistry typeRegistry, @NotNull Resource currentResource) {
+    /**
+     * Returns an executable schema for the given SDL hash. When the executable schema cache is enabled,
+     * concurrent callers for the same hash share a single in-flight build (per-key single-flight).
+     */
+    GraphQLSchema getExecutableSchema(@NotNull String schemaHash, @NotNull TypeDefinitionRegistry typeRegistry) {
+        if (!executableSchemaCacheEnabled) {
+            return buildSchema(typeRegistry);
+        }
+
+        synchronized (executableSchemaCacheLock) {
+            GraphQLSchema cached = hashToExecutableSchemaMap.get(schemaHash);
+            if (cached != null) {
+                return cached;
+            }
+        }
+
+        final CompletableFuture<GraphQLSchema> created = new CompletableFuture<>();
+        final CompletableFuture<GraphQLSchema> existing = executableSchemaInFlight.putIfAbsent(schemaHash, created);
+        if (existing != null) {
+            try {
+                return existing.get();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new SlingGraphQLException("Interrupted while waiting for executable schema build", e);
+            } catch (ExecutionException e) {
+                Throwable cause = e.getCause() != null ? e.getCause() : e;
+                if (cause instanceof RuntimeException) {
+                    throw (RuntimeException) cause;
+                }
+                throw new SlingGraphQLException("Executable schema build failed", cause);
+            }
+        }
+
+        try {
+            final GraphQLSchema built = buildSchema(typeRegistry);
+            synchronized (executableSchemaCacheLock) {
+                hashToExecutableSchemaMap.put(schemaHash, built);
+            }
+            created.complete(built);
+            return built;
+        } catch (RuntimeException e) {
+            created.completeExceptionally(e);
+            throw e;
+        } catch (Exception e) {
+            created.completeExceptionally(e);
+            throw new SlingGraphQLException("Executable schema build failed", e);
+        } finally {
+            executableSchemaInFlight.remove(schemaHash, created);
+        }
+    }
+
+    private GraphQLSchema buildSchema(@NotNull TypeDefinitionRegistry typeRegistry) {
         Iterable<GraphQLScalarType> scalars = scalarsProvider.getCustomScalars(typeRegistry.scalars());
-        RuntimeWiring runtimeWiring = buildWiring(typeRegistry, scalars, currentResource);
+        RuntimeWiring runtimeWiring = buildWiring(typeRegistry, scalars);
         return schemaGenerator.makeExecutableSchema(typeRegistry, runtimeWiring);
     }
 

--- a/src/main/java/org/apache/sling/graphql/core/engine/SlingDataFetcherSelector.java
+++ b/src/main/java/org/apache/sling/graphql/core/engine/SlingDataFetcherSelector.java
@@ -72,11 +72,13 @@ public class SlingDataFetcherSelector {
      * Returns a SlingFetcher from the available OSGi services, if there's one registered with the supplied name.
      */
     private SlingDataFetcher<Object> getOsgiServiceFetcher(@NotNull String name) {
-        TreeSet<ServiceReferenceObjectTuple<SlingDataFetcher<Object>>> fetcherSet = dataFetchers.get(name);
-        if (fetcherSet != null && !fetcherSet.isEmpty()) {
-            return fetcherSet.last().getServiceObject();
+        synchronized (dataFetchers) {
+            TreeSet<ServiceReferenceObjectTuple<SlingDataFetcher<Object>>> fetcherSet = dataFetchers.get(name);
+            if (fetcherSet != null && !fetcherSet.isEmpty()) {
+                return fetcherSet.last().getServiceObject();
+            }
+            return null;
         }
-        return null;
     }
 
     private boolean hasValidName(

--- a/src/main/java/org/apache/sling/graphql/core/engine/SlingDataFetcherWrapper.java
+++ b/src/main/java/org/apache/sling/graphql/core/engine/SlingDataFetcherWrapper.java
@@ -22,24 +22,37 @@ import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.graphql.api.SlingDataFetcher;
+import org.apache.sling.graphql.api.SlingGraphQLException;
 
-/** Wraps a SlingDataFetcher to make it usable by graphql-java */
+/** Wraps a SlingDataFetcher to make it usable by graphql-java.
+ *  The request {@link Resource} is read from {@link graphql.GraphQLContext}
+ *  at fetch time so executable schemas can be reused across requests.
+ */
 class SlingDataFetcherWrapper<T> implements DataFetcher<T> {
 
-    private final SlingDataFetcher<T> fetcher;
-    private final Resource currentResource;
+    private final SlingDataFetcherSelector selector;
+    private final String name;
     private final String options;
     private final String source;
 
-    SlingDataFetcherWrapper(SlingDataFetcher<T> fetcher, Resource currentResource, String options, String source) {
-        this.fetcher = fetcher;
-        this.currentResource = currentResource;
+    SlingDataFetcherWrapper(SlingDataFetcherSelector selector, String name, String options, String source) {
+        this.selector = selector;
+        this.name = name;
         this.options = options;
         this.source = source;
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public T get(DataFetchingEnvironment environment) throws Exception {
+        final Resource currentResource = environment.getGraphQlContext().get(Resource.class);
+        if (currentResource == null) {
+            throw new SlingGraphQLException("GraphQLContext is missing the request Resource");
+        }
+        final SlingDataFetcher<T> fetcher = (SlingDataFetcher<T>) selector.getSlingFetcher(name);
+        if (fetcher == null) {
+            return null;
+        }
         return fetcher.get(new DataFetchingEnvironmentWrapper(environment, currentResource, options, source));
     }
 }

--- a/src/main/java/org/apache/sling/graphql/core/engine/SlingTypeResolverSelector.java
+++ b/src/main/java/org/apache/sling/graphql/core/engine/SlingTypeResolverSelector.java
@@ -69,11 +69,13 @@ public class SlingTypeResolverSelector {
      */
     @Nullable
     public SlingTypeResolver<Object> getSlingTypeResolver(@NotNull String name) {
-        TreeSet<ServiceReferenceObjectTuple<SlingTypeResolver<Object>>> resolvers = typeResolvers.get(name);
-        if (resolvers != null && !resolvers.isEmpty()) {
-            return resolvers.last().getServiceObject();
+        synchronized (typeResolvers) {
+            TreeSet<ServiceReferenceObjectTuple<SlingTypeResolver<Object>>> resolvers = typeResolvers.get(name);
+            if (resolvers != null && !resolvers.isEmpty()) {
+                return resolvers.last().getServiceObject();
+            }
+            return null;
         }
-        return null;
     }
 
     private boolean hasValidName(

--- a/src/main/java/org/apache/sling/graphql/core/engine/SlingTypeResolverWrapper.java
+++ b/src/main/java/org/apache/sling/graphql/core/engine/SlingTypeResolverWrapper.java
@@ -22,28 +22,38 @@ import graphql.TypeResolutionEnvironment;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.TypeResolver;
 import org.apache.sling.api.resource.Resource;
+import org.apache.sling.graphql.api.SlingGraphQLException;
 import org.apache.sling.graphql.api.SlingTypeResolver;
 
 /**
- * Wraps a SlingTypeResolver to make it usable by graphql-java
+ * Wraps a SlingTypeResolver to make it usable by graphql-java.
+ * The request {@link Resource} is read from {@link graphql.GraphQLContext}
+ * at resolve time so executable schemas can be reused across requests.
  */
 class SlingTypeResolverWrapper implements TypeResolver {
 
-    private final SlingTypeResolver<Object> resolver;
-    private final Resource currentResource;
+    private final SlingTypeResolverSelector selector;
+    private final String name;
     private final String options;
     private final String source;
 
-    SlingTypeResolverWrapper(
-            SlingTypeResolver<Object> resolver, Resource currentResource, String options, String source) {
-        this.resolver = resolver;
-        this.currentResource = currentResource;
+    SlingTypeResolverWrapper(SlingTypeResolverSelector selector, String name, String options, String source) {
+        this.selector = selector;
+        this.name = name;
         this.options = options;
         this.source = source;
     }
 
     @Override
     public GraphQLObjectType getType(TypeResolutionEnvironment environment) {
+        final Resource currentResource = environment.getGraphQLContext().get(Resource.class);
+        if (currentResource == null) {
+            throw new SlingGraphQLException("GraphQLContext is missing the request Resource");
+        }
+        final SlingTypeResolver<Object> resolver = selector.getSlingTypeResolver(name);
+        if (resolver == null) {
+            return null;
+        }
         Object r = resolver.getType(new TypeResolverEnvironmentWrapper(environment, currentResource, options, source));
         if (r instanceof GraphQLObjectType) {
             return (GraphQLObjectType) r;

--- a/src/main/java/org/apache/sling/graphql/core/scalars/SlingScalarsProvider.java
+++ b/src/main/java/org/apache/sling/graphql/core/scalars/SlingScalarsProvider.java
@@ -92,11 +92,14 @@ public class SlingScalarsProvider {
         if (ScalarInfo.isGraphqlSpecifiedScalar(name)) {
             return null;
         }
-        TreeSet<ServiceReferenceObjectTuple<SlingScalarConverter<Object, Object>>> set = scalars.get(name);
-        if (set == null || set.isEmpty()) {
-            throw new SlingGraphQLException("SlingScalarConverter with name '" + name + "' not found");
+        final SlingScalarConverter<Object, Object> converter;
+        synchronized (scalars) {
+            TreeSet<ServiceReferenceObjectTuple<SlingScalarConverter<Object, Object>>> set = scalars.get(name);
+            if (set == null || set.isEmpty()) {
+                throw new SlingGraphQLException("SlingScalarConverter with name '" + name + "' not found");
+            }
+            converter = set.last().getServiceObject();
         }
-        SlingScalarConverter<Object, Object> converter = set.last().getServiceObject();
 
         return GraphQLScalarType.newScalar()
                 .name(name)

--- a/src/main/java/org/apache/sling/graphql/core/scalars/SlingScalarsProvider.java
+++ b/src/main/java/org/apache/sling/graphql/core/scalars/SlingScalarsProvider.java
@@ -19,10 +19,12 @@
 package org.apache.sling.graphql.core.scalars;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 import graphql.language.ScalarTypeDefinition;
@@ -53,6 +55,12 @@ public class SlingScalarsProvider {
     private final Map<String, TreeSet<ServiceReferenceObjectTuple<SlingScalarConverter<Object, Object>>>> scalars =
             new HashMap<>();
 
+    /**
+     * Monotonic revision of the converter set. Bumped after every successful bind/unbind map update
+     * so callers can detect whether a schema built from an earlier snapshot is still current.
+     */
+    private final AtomicLong scalarGeneration = new AtomicLong();
+
     @Reference(
             service = SlingScalarConverter.class,
             cardinality = ReferenceCardinality.MULTIPLE,
@@ -66,6 +74,7 @@ public class SlingScalarsProvider {
                 TreeSet<ServiceReferenceObjectTuple<SlingScalarConverter<Object, Object>>> set =
                         scalars.computeIfAbsent(name, key -> new TreeSet<>());
                 set.add(new ServiceReferenceObjectTuple<>(serviceReference, scalarConverter));
+                scalarGeneration.incrementAndGet();
             }
         }
     }
@@ -81,26 +90,47 @@ public class SlingScalarsProvider {
                             set.stream()
                                     .filter(tuple -> serviceReference.equals(tuple.getServiceReference()))
                                     .findFirst();
-                    tupleToRemove.ifPresent(set::remove);
+                    if (tupleToRemove.isPresent()) {
+                        set.remove(tupleToRemove.get());
+                        scalarGeneration.incrementAndGet();
+                    }
                 }
             }
         }
     }
 
-    private GraphQLScalarType getScalar(String name) {
-        // Ignore standard scalars
+    /**
+     * @return current scalar converter generation; safe to sample outside a build and re-check before cache publish
+     */
+    public long getScalarGeneration() {
+        return scalarGeneration.get();
+    }
+
+    /**
+     * Returns custom scalars for the given schema together with the converter generation observed while
+     * reading the map, so the caller can refuse to cache if converters change before publication.
+     */
+    public CustomScalars getCustomScalars(Map<String, ScalarTypeDefinition> schemaScalars) {
+        synchronized (scalars) {
+            long generation = scalarGeneration.get();
+            List<GraphQLScalarType> list = schemaScalars.keySet().stream()
+                    .map(this::getScalarLocked)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList());
+            return new CustomScalars(generation, list);
+        }
+    }
+
+    /** Must be called while holding {@code scalars} lock. */
+    private GraphQLScalarType getScalarLocked(String name) {
         if (ScalarInfo.isGraphqlSpecifiedScalar(name)) {
             return null;
         }
-        final SlingScalarConverter<Object, Object> converter;
-        synchronized (scalars) {
-            TreeSet<ServiceReferenceObjectTuple<SlingScalarConverter<Object, Object>>> set = scalars.get(name);
-            if (set == null || set.isEmpty()) {
-                throw new SlingGraphQLException("SlingScalarConverter with name '" + name + "' not found");
-            }
-            converter = set.last().getServiceObject();
+        TreeSet<ServiceReferenceObjectTuple<SlingScalarConverter<Object, Object>>> set = scalars.get(name);
+        if (set == null || set.isEmpty()) {
+            throw new SlingGraphQLException("SlingScalarConverter with name '" + name + "' not found");
         }
-
+        SlingScalarConverter<Object, Object> converter = set.last().getServiceObject();
         return GraphQLScalarType.newScalar()
                 .name(name)
                 .description(converter.toString())
@@ -108,11 +138,24 @@ public class SlingScalarsProvider {
                 .build();
     }
 
-    public Iterable<GraphQLScalarType> getCustomScalars(Map<String, ScalarTypeDefinition> schemaScalars) {
-        // Using just the names for now, not sure why we'd need the ScalarTypeDefinitions
-        return schemaScalars.keySet().stream()
-                .map(this::getScalar)
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+    /**
+     * Snapshot of custom scalar types plus the provider generation at read time.
+     */
+    public static final class CustomScalars {
+        private final long generation;
+        private final Iterable<GraphQLScalarType> scalars;
+
+        public CustomScalars(long generation, Iterable<GraphQLScalarType> scalars) {
+            this.generation = generation;
+            this.scalars = scalars;
+        }
+
+        public long getGeneration() {
+            return generation;
+        }
+
+        public Iterable<GraphQLScalarType> getScalars() {
+            return scalars;
+        }
     }
 }

--- a/src/test/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutorCacheTest.java
+++ b/src/test/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutorCacheTest.java
@@ -49,6 +49,7 @@ import org.mockito.stubbing.Answer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -172,7 +173,7 @@ public class DefaultQueryExecutorCacheTest {
         assertNotNull(first);
         assertNotNull(second);
         // Without the cache each call creates a new GraphQLSchema instance
-        assertTrue(first != second);
+        assertNotSame(first, second);
     }
 
     @Test
@@ -184,13 +185,17 @@ public class DefaultQueryExecutorCacheTest {
 
         final AtomicInteger buildCalls = new AtomicInteger();
         final CountDownLatch started = new CountDownLatch(1);
+        final CountDownLatch buildStarted = new CountDownLatch(1);
+        final CountDownLatch releaseBuild = new CountDownLatch(1);
         final CyclicBarrier barrier = new CyclicBarrier(8, started::countDown);
 
-        // Wrap scalars lookup to observe how often buildSchema runs
+        // Hold the winner in buildSchema until other threads have joined the in-flight Future
         when(scalarsProvider.getCustomScalars(any())).thenAnswer((Answer<Iterable>) invocation -> {
             buildCalls.incrementAndGet();
-            // Hold the winner briefly so waiters join the in-flight Future
-            Thread.sleep(50);
+            buildStarted.countDown();
+            if (!releaseBuild.await(5, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("Timed out waiting to release schema build");
+            }
             return Collections.emptyList();
         });
 
@@ -204,6 +209,8 @@ public class DefaultQueryExecutorCacheTest {
                 }));
             }
             assertTrue(started.await(5, TimeUnit.SECONDS));
+            assertTrue(buildStarted.await(5, TimeUnit.SECONDS));
+            releaseBuild.countDown();
 
             GraphQLSchema first = null;
             for (Future<GraphQLSchema> future : futures) {
@@ -215,9 +222,9 @@ public class DefaultQueryExecutorCacheTest {
                     assertSame(first, schema);
                 }
             }
-            assertTrue(
-                    "Expected a single schema build under contention, got " + buildCalls.get(), buildCalls.get() == 1);
+            assertEquals("Expected a single schema build under contention", 1, buildCalls.get());
         } finally {
+            releaseBuild.countDown();
             pool.shutdownNow();
         }
     }
@@ -306,8 +313,14 @@ public class DefaultQueryExecutorCacheTest {
         });
         waiter.start();
         assertTrue(entered.await(5, TimeUnit.SECONDS));
-        // Allow the thread to block inside Future.get()
-        Thread.sleep(50);
+        // Wait until the thread is blocked inside Future.get()
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (waiter.getState() != Thread.State.WAITING && waiter.getState() != Thread.State.TIMED_WAITING) {
+            if (System.nanoTime() > deadline) {
+                fail("Waiter thread did not block on Future.get()");
+            }
+            Thread.yield();
+        }
         waiter.interrupt();
         assertTrue(done.await(5, TimeUnit.SECONDS));
         assertEquals(1, failures.get());

--- a/src/test/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutorCacheTest.java
+++ b/src/test/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutorCacheTest.java
@@ -83,7 +83,13 @@ public class DefaultQueryExecutorCacheTest {
     public void setUp() {
         activate(10, false);
         when(resource.getPath()).thenReturn("/content/test");
-        when(scalarsProvider.getCustomScalars(any())).thenReturn(Collections.emptyList());
+        stubStableScalars();
+    }
+
+    private void stubStableScalars() {
+        when(scalarsProvider.getCustomScalars(any()))
+                .thenReturn(new SlingScalarsProvider.CustomScalars(0L, Collections.emptyList()));
+        when(scalarsProvider.getScalarGeneration()).thenReturn(0L);
     }
 
     private void activate(int schemaCacheSize, boolean executableSchemaCacheEnabled) {
@@ -190,14 +196,16 @@ public class DefaultQueryExecutorCacheTest {
         final CyclicBarrier barrier = new CyclicBarrier(8, started::countDown);
 
         // Hold the winner in buildSchema until other threads have joined the in-flight Future
-        when(scalarsProvider.getCustomScalars(any())).thenAnswer((Answer<Iterable>) invocation -> {
-            buildCalls.incrementAndGet();
-            buildStarted.countDown();
-            if (!releaseBuild.await(5, TimeUnit.SECONDS)) {
-                throw new IllegalStateException("Timed out waiting to release schema build");
-            }
-            return Collections.emptyList();
-        });
+        when(scalarsProvider.getCustomScalars(any()))
+                .thenAnswer((Answer<SlingScalarsProvider.CustomScalars>) invocation -> {
+                    buildCalls.incrementAndGet();
+                    buildStarted.countDown();
+                    if (!releaseBuild.await(5, TimeUnit.SECONDS)) {
+                        throw new IllegalStateException("Timed out waiting to release schema build");
+                    }
+                    return new SlingScalarsProvider.CustomScalars(0L, Collections.emptyList());
+                });
+        when(scalarsProvider.getScalarGeneration()).thenReturn(0L);
 
         ExecutorService pool = Executors.newFixedThreadPool(8);
         List<Future<GraphQLSchema>> futures = new ArrayList<>();
@@ -227,6 +235,26 @@ public class DefaultQueryExecutorCacheTest {
             releaseBuild.countDown();
             pool.shutdownNow();
         }
+    }
+
+    @Test
+    public void testExecutableSchemaCache_SkipsPublishWhenScalarGenerationChanges() {
+        activate(10, true);
+        String sdl = "type Query { hello: String }";
+        TypeDefinitionRegistry registry = executor.getTypeDefinitionRegistry(sdl, resource, new String[] {"test"});
+        String hash = SHA256Hasher.getHash(sdl);
+
+        when(scalarsProvider.getCustomScalars(any()))
+                .thenReturn(new SlingScalarsProvider.CustomScalars(1L, Collections.emptyList()));
+        // Generation moved on before publish → must not cache
+        when(scalarsProvider.getScalarGeneration()).thenReturn(2L);
+
+        GraphQLSchema first = executor.getExecutableSchema(hash, registry);
+        GraphQLSchema second = executor.getExecutableSchema(hash, registry);
+
+        assertNotNull(first);
+        assertNotNull(second);
+        assertNotSame(first, second);
     }
 
     @Test

--- a/src/test/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutorCacheTest.java
+++ b/src/test/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutorCacheTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import graphql.schema.GraphQLSchema;
 import graphql.schema.idl.TypeDefinitionRegistry;
@@ -308,6 +309,68 @@ public class DefaultQueryExecutorCacheTest {
 
         when(scalarsProvider.getScalarGeneration()).thenReturn(1L);
         assertSame(newer, executor.getExecutableSchema(hash, registry));
+    }
+
+    @Test
+    public void testExecutableSchemaCache_ErrorDuringBuildUnblocksWaiters() throws Exception {
+        activate(10, true);
+        String sdl = "type Query { hello: String }";
+        TypeDefinitionRegistry registry = executor.getTypeDefinitionRegistry(sdl, resource, new String[] {"test"});
+        String hash = SHA256Hasher.getHash(sdl);
+
+        final CountDownLatch buildStarted = new CountDownLatch(1);
+        final CountDownLatch releaseBuild = new CountDownLatch(1);
+        when(scalarsProvider.getCustomScalars(any())).thenAnswer(invocation -> {
+            buildStarted.countDown();
+            if (!releaseBuild.await(5, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("Timed out waiting to release schema build");
+            }
+            throw new AssertionError("simulated builder abort");
+        });
+
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        try {
+            Future<?> builder = pool.submit(() -> {
+                try {
+                    executor.getExecutableSchema(hash, registry);
+                    fail("Expected AssertionError");
+                } catch (AssertionError expected) {
+                    assertEquals("simulated builder abort", expected.getMessage());
+                }
+            });
+            assertTrue(buildStarted.await(5, TimeUnit.SECONDS));
+
+            final AtomicReference<Thread> waiterThread = new AtomicReference<>();
+            Future<?> waiter = pool.submit(() -> {
+                waiterThread.set(Thread.currentThread());
+                try {
+                    executor.getExecutableSchema(hash, registry);
+                    fail("Expected IllegalStateException from aborted build");
+                } catch (IllegalStateException e) {
+                    assertTrue(e.getMessage().contains("aborted"));
+                }
+            });
+
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+            while (true) {
+                Thread t = waiterThread.get();
+                if (t != null && (t.getState() == Thread.State.WAITING || t.getState() == Thread.State.TIMED_WAITING)) {
+                    break;
+                }
+                if (System.nanoTime() > deadline) {
+                    fail("Waiter thread did not block on in-flight Future.get()");
+                }
+                Thread.yield();
+            }
+
+            releaseBuild.countDown();
+            builder.get(10, TimeUnit.SECONDS);
+            waiter.get(10, TimeUnit.SECONDS);
+            assertTrue(inFlightMap().isEmpty());
+        } finally {
+            releaseBuild.countDown();
+            pool.shutdownNow();
+        }
     }
 
     @Test

--- a/src/test/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutorCacheTest.java
+++ b/src/test/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutorCacheTest.java
@@ -18,8 +18,21 @@
  */
 package org.apache.sling.graphql.core.engine;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import graphql.schema.GraphQLSchema;
 import graphql.schema.idl.TypeDefinitionRegistry;
 import org.apache.sling.api.resource.Resource;
+import org.apache.sling.graphql.core.hash.SHA256Hasher;
 import org.apache.sling.graphql.core.scalars.SlingScalarsProvider;
 import org.apache.sling.graphql.core.schema.RankedSchemaProviders;
 import org.junit.Before;
@@ -28,9 +41,15 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DefaultQueryExecutorCacheTest {
@@ -55,16 +74,19 @@ public class DefaultQueryExecutorCacheTest {
 
     @Before
     public void setUp() {
-        // Activate the component with default config
+        activate(10, false);
+        when(resource.getPath()).thenReturn("/content/test");
+        when(scalarsProvider.getCustomScalars(any())).thenReturn(Collections.emptyList());
+    }
+
+    private void activate(int schemaCacheSize, boolean executableSchemaCacheEnabled) {
         DefaultQueryExecutor.Config config = mock(DefaultQueryExecutor.Config.class);
-        when(config.schemaCacheSize()).thenReturn(10);
+        when(config.schemaCacheSize()).thenReturn(schemaCacheSize);
+        when(config.executableSchemaCacheEnabled()).thenReturn(executableSchemaCacheEnabled);
         when(config.maxQueryTokens()).thenReturn(15000);
         when(config.maxWhitespaceTokens()).thenReturn(200000);
         when(config.maxFieldCount()).thenReturn(100000);
-
         executor.activate(config);
-
-        when(resource.getPath()).thenReturn("/content/test");
     }
 
     @Test
@@ -90,9 +112,7 @@ public class DefaultQueryExecutorCacheTest {
 
     @Test
     public void testGetTypeDefinitionRegistry_CacheDisabled() {
-        DefaultQueryExecutor.Config config = mock(DefaultQueryExecutor.Config.class);
-        when(config.schemaCacheSize()).thenReturn(0);
-        executor.activate(config);
+        activate(0, false);
 
         String sdl = "type Query { hello: String }";
         String[] selectors = {"test"};
@@ -107,9 +127,7 @@ public class DefaultQueryExecutorCacheTest {
         Resource resource2 = mock(Resource.class);
         when(resource2.getPath()).thenReturn("/content/test2");
 
-        DefaultQueryExecutor.Config config = mock(DefaultQueryExecutor.Config.class);
-        when(config.schemaCacheSize()).thenReturn(2);
-        executor.activate(config);
+        activate(2, false);
 
         String sdl = "type Query { hello: String }";
         String[] selectors = {"test"};
@@ -119,5 +137,82 @@ public class DefaultQueryExecutorCacheTest {
         executor.getTypeDefinitionRegistry(sdl + "  ", resource, selectors);
         TypeDefinitionRegistry result = executor.getTypeDefinitionRegistry(sdl, resource2, selectors);
         assertNotNull(result);
+    }
+
+    @Test
+    public void testExecutableSchemaCache_ReusesSameInstance() {
+        activate(10, true);
+        String sdl = "type Query { hello: String }";
+        TypeDefinitionRegistry registry = executor.getTypeDefinitionRegistry(sdl, resource, new String[] {"test"});
+        String hash = SHA256Hasher.getHash(sdl);
+
+        GraphQLSchema first = executor.getExecutableSchema(hash, registry);
+        GraphQLSchema second = executor.getExecutableSchema(hash, registry);
+
+        assertNotNull(first);
+        assertSame(first, second);
+    }
+
+    @Test
+    public void testExecutableSchemaCache_DisabledBuildsIndependently() {
+        activate(10, false);
+        String sdl = "type Query { hello: String }";
+        TypeDefinitionRegistry registry = executor.getTypeDefinitionRegistry(sdl, resource, new String[] {"test"});
+        String hash = SHA256Hasher.getHash(sdl);
+
+        GraphQLSchema first = executor.getExecutableSchema(hash, registry);
+        GraphQLSchema second = executor.getExecutableSchema(hash, registry);
+
+        assertNotNull(first);
+        assertNotNull(second);
+        // Without the cache each call creates a new GraphQLSchema instance
+        assertTrue(first != second);
+    }
+
+    @Test
+    public void testExecutableSchemaCache_SingleFlightUnderContention() throws Exception {
+        activate(10, true);
+        String sdl = "type Query { hello: String }";
+        TypeDefinitionRegistry registry = executor.getTypeDefinitionRegistry(sdl, resource, new String[] {"test"});
+        String hash = SHA256Hasher.getHash(sdl);
+
+        final AtomicInteger buildCalls = new AtomicInteger();
+        final CountDownLatch started = new CountDownLatch(1);
+        final CyclicBarrier barrier = new CyclicBarrier(8, started::countDown);
+
+        // Wrap scalars lookup to observe how often buildSchema runs
+        when(scalarsProvider.getCustomScalars(any())).thenAnswer((Answer<Iterable>) invocation -> {
+            buildCalls.incrementAndGet();
+            // Hold the winner briefly so waiters join the in-flight Future
+            Thread.sleep(50);
+            return Collections.emptyList();
+        });
+
+        ExecutorService pool = Executors.newFixedThreadPool(8);
+        List<Future<GraphQLSchema>> futures = new ArrayList<>();
+        try {
+            for (int i = 0; i < 8; i++) {
+                futures.add(pool.submit(() -> {
+                    barrier.await(5, TimeUnit.SECONDS);
+                    return executor.getExecutableSchema(hash, registry);
+                }));
+            }
+            assertTrue(started.await(5, TimeUnit.SECONDS));
+
+            GraphQLSchema first = null;
+            for (Future<GraphQLSchema> future : futures) {
+                GraphQLSchema schema = future.get(10, TimeUnit.SECONDS);
+                assertNotNull(schema);
+                if (first == null) {
+                    first = schema;
+                } else {
+                    assertSame(first, schema);
+                }
+            }
+            assertTrue(
+                    "Expected a single schema build under contention, got " + buildCalls.get(), buildCalls.get() == 1);
+        } finally {
+            pool.shutdownNow();
+        }
     }
 }

--- a/src/test/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutorCacheTest.java
+++ b/src/test/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutorCacheTest.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
@@ -238,7 +239,7 @@ public class DefaultQueryExecutorCacheTest {
     }
 
     @Test
-    public void testExecutableSchemaCache_SkipsPublishWhenScalarGenerationChanges() {
+    public void testExecutableSchemaCache_FailsWhenScalarGenerationNeverStabilizes() {
         activate(10, true);
         String sdl = "type Query { hello: String }";
         TypeDefinitionRegistry registry = executor.getTypeDefinitionRegistry(sdl, resource, new String[] {"test"});
@@ -246,15 +247,67 @@ public class DefaultQueryExecutorCacheTest {
 
         when(scalarsProvider.getCustomScalars(any()))
                 .thenReturn(new SlingScalarsProvider.CustomScalars(1L, Collections.emptyList()));
-        // Generation moved on before publish → must not cache
+        // Live generation always ahead of the snapshot used for wiring → never stable
         when(scalarsProvider.getScalarGeneration()).thenReturn(2L);
 
-        GraphQLSchema first = executor.getExecutableSchema(hash, registry);
-        GraphQLSchema second = executor.getExecutableSchema(hash, registry);
+        try {
+            executor.getExecutableSchema(hash, registry);
+            fail("Expected SlingGraphQLException when generation never stabilizes");
+        } catch (SlingGraphQLException e) {
+            assertTrue(e.getMessage().contains("did not stabilize"));
+        }
+    }
 
-        assertNotNull(first);
-        assertNotNull(second);
-        assertNotSame(first, second);
+    @Test
+    public void testExecutableSchemaCache_RetriesUntilScalarGenerationStabilizes() {
+        activate(10, true);
+        String sdl = "type Query { hello: String }";
+        TypeDefinitionRegistry registry = executor.getTypeDefinitionRegistry(sdl, resource, new String[] {"test"});
+        String hash = SHA256Hasher.getHash(sdl);
+
+        final AtomicInteger liveGeneration = new AtomicInteger(1);
+        when(scalarsProvider.getScalarGeneration()).thenAnswer(invocation -> (long) liveGeneration.get());
+        when(scalarsProvider.getCustomScalars(any())).thenAnswer(invocation -> {
+            long snapshot = liveGeneration.get();
+            // First build sees generation bump before publish; subsequent builds are stable.
+            if (snapshot == 1) {
+                liveGeneration.set(2);
+            }
+            return new SlingScalarsProvider.CustomScalars(snapshot, Collections.emptyList());
+        });
+
+        GraphQLSchema schema = executor.getExecutableSchema(hash, registry);
+        assertNotNull(schema);
+        assertEquals(2, liveGeneration.get());
+        assertSame(schema, executor.getExecutableSchema(hash, registry));
+    }
+
+    @Test
+    public void testExecutableSchemaCache_OldGenerationCallerDoesNotClobberNewerEntry() throws Exception {
+        activate(10, true);
+        String sdl = "type Query { hello: String }";
+        TypeDefinitionRegistry registry = executor.getTypeDefinitionRegistry(sdl, resource, new String[] {"test"});
+        String hash = SHA256Hasher.getHash(sdl);
+
+        when(scalarsProvider.getScalarGeneration()).thenReturn(1L);
+        when(scalarsProvider.getCustomScalars(any()))
+                .thenReturn(new SlingScalarsProvider.CustomScalars(1L, Collections.emptyList()));
+        GraphQLSchema newer = executor.getExecutableSchema(hash, registry);
+        assertNotNull(newer);
+        assertEquals(1L, cachedGeneration(hash));
+
+        // Delayed old-generation caller
+        when(scalarsProvider.getScalarGeneration()).thenReturn(0L);
+        when(scalarsProvider.getCustomScalars(any()))
+                .thenReturn(new SlingScalarsProvider.CustomScalars(0L, Collections.emptyList()));
+        GraphQLSchema older = executor.getExecutableSchema(hash, registry);
+        assertNotNull(older);
+        assertNotSame(newer, older);
+        // Newer cache entry must remain
+        assertEquals(1L, cachedGeneration(hash));
+
+        when(scalarsProvider.getScalarGeneration()).thenReturn(1L);
+        assertSame(newer, executor.getExecutableSchema(hash, registry));
     }
 
     @Test
@@ -386,5 +439,17 @@ public class DefaultQueryExecutorCacheTest {
         Field field = DefaultQueryExecutor.class.getDeclaredField("executableSchemaInFlight");
         field.setAccessible(true);
         return (ConcurrentHashMap<String, CompletableFuture<?>>) field.get(executor);
+    }
+
+    private long cachedGeneration(String schemaHash) throws Exception {
+        Field field = DefaultQueryExecutor.class.getDeclaredField("hashToExecutableSchemaMap");
+        field.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<String, ?> map = (Map<String, ?>) field.get(executor);
+        Object entry = map.get(schemaHash);
+        assertNotNull(entry);
+        Field genField = entry.getClass().getDeclaredField("scalarGeneration");
+        genField.setAccessible(true);
+        return genField.getLong(entry);
     }
 }

--- a/src/test/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutorCacheTest.java
+++ b/src/test/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutorCacheTest.java
@@ -18,9 +18,12 @@
  */
 package org.apache.sling.graphql.core.engine;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
@@ -32,6 +35,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.idl.TypeDefinitionRegistry;
 import org.apache.sling.api.resource.Resource;
+import org.apache.sling.graphql.api.SlingGraphQLException;
 import org.apache.sling.graphql.core.hash.SHA256Hasher;
 import org.apache.sling.graphql.core.scalars.SlingScalarsProvider;
 import org.apache.sling.graphql.core.schema.RankedSchemaProviders;
@@ -43,10 +47,12 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -214,5 +220,104 @@ public class DefaultQueryExecutorCacheTest {
         } finally {
             pool.shutdownNow();
         }
+    }
+
+    @Test
+    public void testExecutableSchemaCache_BuildRuntimeExceptionPropagates() {
+        activate(10, true);
+        String sdl = "type Query { hello: String }";
+        TypeDefinitionRegistry registry = executor.getTypeDefinitionRegistry(sdl, resource, new String[] {"test"});
+        String hash = SHA256Hasher.getHash(sdl);
+
+        when(scalarsProvider.getCustomScalars(any())).thenThrow(new IllegalStateException("boom"));
+
+        try {
+            executor.getExecutableSchema(hash, registry);
+            fail("Expected IllegalStateException");
+        } catch (IllegalStateException e) {
+            assertEquals("boom", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testExecutableSchemaCache_WaiterSeesRuntimeFailure() throws Exception {
+        activate(10, true);
+        String sdl = "type Query { hello: String }";
+        TypeDefinitionRegistry registry = executor.getTypeDefinitionRegistry(sdl, resource, new String[] {"test"});
+        String hash = SHA256Hasher.getHash(sdl);
+
+        CompletableFuture<GraphQLSchema> failed = new CompletableFuture<>();
+        failed.completeExceptionally(new IllegalStateException("build failed"));
+        inFlightMap().put(hash, failed);
+
+        try {
+            executor.getExecutableSchema(hash, registry);
+            fail("Expected IllegalStateException");
+        } catch (IllegalStateException e) {
+            assertEquals("build failed", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testExecutableSchemaCache_WaiterSeesNonRuntimeFailure() throws Exception {
+        activate(10, true);
+        String sdl = "type Query { hello: String }";
+        TypeDefinitionRegistry registry = executor.getTypeDefinitionRegistry(sdl, resource, new String[] {"test"});
+        String hash = SHA256Hasher.getHash(sdl);
+
+        CompletableFuture<GraphQLSchema> failed = new CompletableFuture<>();
+        failed.completeExceptionally(new Exception("checked failure"));
+        inFlightMap().put(hash, failed);
+
+        try {
+            executor.getExecutableSchema(hash, registry);
+            fail("Expected SlingGraphQLException");
+        } catch (SlingGraphQLException e) {
+            assertTrue(e.getMessage().contains("Executable schema build failed"));
+            assertEquals("checked failure", e.getCause().getMessage());
+        }
+    }
+
+    @Test
+    public void testExecutableSchemaCache_WaiterInterrupted() throws Exception {
+        activate(10, true);
+        String sdl = "type Query { hello: String }";
+        TypeDefinitionRegistry registry = executor.getTypeDefinitionRegistry(sdl, resource, new String[] {"test"});
+        String hash = SHA256Hasher.getHash(sdl);
+
+        // Never-completing future so the waiter blocks in Future.get()
+        inFlightMap().put(hash, new CompletableFuture<>());
+
+        final CountDownLatch entered = new CountDownLatch(1);
+        final CountDownLatch done = new CountDownLatch(1);
+        final AtomicInteger failures = new AtomicInteger();
+        Thread waiter = new Thread(() -> {
+            try {
+                entered.countDown();
+                executor.getExecutableSchema(hash, registry);
+            } catch (SlingGraphQLException e) {
+                if (e.getMessage().contains("Interrupted while waiting")
+                        && Thread.currentThread().isInterrupted()) {
+                    failures.incrementAndGet();
+                }
+            } finally {
+                done.countDown();
+            }
+        });
+        waiter.start();
+        assertTrue(entered.await(5, TimeUnit.SECONDS));
+        // Allow the thread to block inside Future.get()
+        Thread.sleep(50);
+        waiter.interrupt();
+        assertTrue(done.await(5, TimeUnit.SECONDS));
+        assertEquals(1, failures.get());
+        inFlightMap().clear();
+    }
+
+    @SuppressWarnings("unchecked")
+    private ConcurrentHashMap<String, CompletableFuture<GraphQLSchema>> inFlightMap() throws Exception {
+        Field field = DefaultQueryExecutor.class.getDeclaredField("executableSchemaInFlight");
+        field.setAccessible(true);
+        return (ConcurrentHashMap<String, CompletableFuture<GraphQLSchema>>) field.get(executor);
     }
 }

--- a/src/test/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutorCacheTest.java
+++ b/src/test/java/org/apache/sling/graphql/core/engine/DefaultQueryExecutorCacheTest.java
@@ -275,15 +275,39 @@ public class DefaultQueryExecutorCacheTest {
     }
 
     @Test
+    public void testExecutableSchemaCache_RejectsStaleCacheEntryOnHit() {
+        activate(10, true);
+        String sdl = "type Query { hello: String }";
+        TypeDefinitionRegistry registry = executor.getTypeDefinitionRegistry(sdl, resource, new String[] {"test"});
+        String hash = SHA256Hasher.getHash(sdl);
+
+        GraphQLSchema first = executor.getExecutableSchema(hash, registry);
+        assertNotNull(first);
+        assertSame(first, executor.getExecutableSchema(hash, registry));
+
+        // Converter set changed after the entry was cached
+        when(scalarsProvider.getScalarGeneration()).thenReturn(1L);
+        when(scalarsProvider.getCustomScalars(any()))
+                .thenReturn(new SlingScalarsProvider.CustomScalars(1L, Collections.emptyList()));
+
+        GraphQLSchema second = executor.getExecutableSchema(hash, registry);
+        assertNotNull(second);
+        assertNotSame(first, second);
+        assertSame(second, executor.getExecutableSchema(hash, registry));
+    }
+
+    @Test
     public void testExecutableSchemaCache_WaiterSeesRuntimeFailure() throws Exception {
         activate(10, true);
         String sdl = "type Query { hello: String }";
         TypeDefinitionRegistry registry = executor.getTypeDefinitionRegistry(sdl, resource, new String[] {"test"});
         String hash = SHA256Hasher.getHash(sdl);
 
-        CompletableFuture<GraphQLSchema> failed = new CompletableFuture<>();
+        CompletableFuture<Object> failed = new CompletableFuture<>();
         failed.completeExceptionally(new IllegalStateException("build failed"));
-        inFlightMap().put(hash, failed);
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        CompletableFuture raw = failed;
+        inFlightMap().put(hash + ":0", raw);
 
         try {
             executor.getExecutableSchema(hash, registry);
@@ -300,9 +324,11 @@ public class DefaultQueryExecutorCacheTest {
         TypeDefinitionRegistry registry = executor.getTypeDefinitionRegistry(sdl, resource, new String[] {"test"});
         String hash = SHA256Hasher.getHash(sdl);
 
-        CompletableFuture<GraphQLSchema> failed = new CompletableFuture<>();
+        CompletableFuture<Object> failed = new CompletableFuture<>();
         failed.completeExceptionally(new Exception("checked failure"));
-        inFlightMap().put(hash, failed);
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        CompletableFuture raw = failed;
+        inFlightMap().put(hash + ":0", raw);
 
         try {
             executor.getExecutableSchema(hash, registry);
@@ -321,7 +347,7 @@ public class DefaultQueryExecutorCacheTest {
         String hash = SHA256Hasher.getHash(sdl);
 
         // Never-completing future so the waiter blocks in Future.get()
-        inFlightMap().put(hash, new CompletableFuture<>());
+        inFlightMap().put(hash + ":0", new CompletableFuture<>());
 
         final CountDownLatch entered = new CountDownLatch(1);
         final CountDownLatch done = new CountDownLatch(1);
@@ -356,9 +382,9 @@ public class DefaultQueryExecutorCacheTest {
     }
 
     @SuppressWarnings("unchecked")
-    private ConcurrentHashMap<String, CompletableFuture<GraphQLSchema>> inFlightMap() throws Exception {
+    private ConcurrentHashMap<String, CompletableFuture<?>> inFlightMap() throws Exception {
         Field field = DefaultQueryExecutor.class.getDeclaredField("executableSchemaInFlight");
         field.setAccessible(true);
-        return (ConcurrentHashMap<String, CompletableFuture<GraphQLSchema>>) field.get(executor);
+        return (ConcurrentHashMap<String, CompletableFuture<?>>) field.get(executor);
     }
 }

--- a/src/test/java/org/apache/sling/graphql/core/engine/ExecutableSchemaCacheExecuteTest.java
+++ b/src/test/java/org/apache/sling/graphql/core/engine/ExecutableSchemaCacheExecuteTest.java
@@ -27,13 +27,14 @@ import org.apache.sling.graphql.api.engine.QueryExecutor;
 import org.apache.sling.graphql.core.mocks.EchoDataFetcher;
 import org.apache.sling.graphql.core.mocks.TestUtil;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * End-to-end execute() coverage with the executable schema cache enabled,
@@ -79,9 +80,9 @@ public class ExecutableSchemaCacheExecuteTest extends ResourceQueryTestBase {
     }
 
     private static Resource mockResource(String path, String resourceType) {
-        Resource r = Mockito.mock(Resource.class);
-        Mockito.when(r.getPath()).thenReturn(path);
-        Mockito.when(r.getResourceType()).thenReturn(resourceType);
+        Resource r = mock(Resource.class);
+        when(r.getPath()).thenReturn(path);
+        when(r.getResourceType()).thenReturn(resourceType);
         return r;
     }
 }

--- a/src/test/java/org/apache/sling/graphql/core/engine/ExecutableSchemaCacheExecuteTest.java
+++ b/src/test/java/org/apache/sling/graphql/core/engine/ExecutableSchemaCacheExecuteTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.graphql.core.engine;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.graphql.api.engine.QueryExecutor;
+import org.apache.sling.graphql.core.mocks.EchoDataFetcher;
+import org.apache.sling.graphql.core.mocks.TestUtil;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * End-to-end execute() coverage with the executable schema cache enabled,
+ * verifying GraphQLContext Resource isolation across distinct request resources.
+ */
+public class ExecutableSchemaCacheExecuteTest extends ResourceQueryTestBase {
+
+    @Override
+    protected Map<String, Object> getQueryExecutorProperties() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("executableSchemaCacheEnabled", true);
+        props.put("schemaCacheSize", 32);
+        return props;
+    }
+
+    @Override
+    protected void setupAdditionalServices() {
+        TestUtil.registerSlingDataFetcher(context.bundleContext(), "echoNS/echo", new EchoDataFetcher(null));
+    }
+
+    @Test
+    public void cachedSchemaUsesPerRequestResource() {
+        final QueryExecutor queryExecutor = context.getService(QueryExecutor.class);
+        assertNotNull(queryExecutor);
+
+        Resource resourceA = mockResource("/content/a-" + UUID.randomUUID(), "type/a");
+        Resource resourceB = mockResource("/content/b-" + UUID.randomUUID(), "type/b");
+
+        final String query = "{ currentResource { path resourceType } }";
+        Map<String, Object> resultA =
+                queryExecutor.execute(query, java.util.Collections.emptyMap(), resourceA, new String[] {});
+        Map<String, Object> resultB =
+                queryExecutor.execute(query, java.util.Collections.emptyMap(), resourceB, new String[] {});
+
+        String jsonA = jakarta.json.Json.createObjectBuilder(resultA).build().toString();
+        String jsonB = jakarta.json.Json.createObjectBuilder(resultB).build().toString();
+
+        assertThat(jsonA, hasJsonPath("$.data.currentResource.path", equalTo(resourceA.getPath())));
+        assertThat(jsonA, hasJsonPath("$.data.currentResource.resourceType", equalTo(resourceA.getResourceType())));
+        assertThat(jsonB, hasJsonPath("$.data.currentResource.path", equalTo(resourceB.getPath())));
+        assertThat(jsonB, hasJsonPath("$.data.currentResource.resourceType", equalTo(resourceB.getResourceType())));
+        assertThat(resourceA.getPath(), not(equalTo(resourceB.getPath())));
+    }
+
+    private static Resource mockResource(String path, String resourceType) {
+        Resource r = Mockito.mock(Resource.class);
+        Mockito.when(r.getPath()).thenReturn(path);
+        Mockito.when(r.getResourceType()).thenReturn(resourceType);
+        return r;
+    }
+}

--- a/src/test/java/org/apache/sling/graphql/core/engine/SlingFetcherResolverWrapperTest.java
+++ b/src/test/java/org/apache/sling/graphql/core/engine/SlingFetcherResolverWrapperTest.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.graphql.core.engine;
+
+import graphql.GraphQLContext;
+import graphql.TypeResolutionEnvironment;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLObjectType;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.graphql.api.SlingDataFetcher;
+import org.apache.sling.graphql.api.SlingGraphQLException;
+import org.apache.sling.graphql.api.SlingTypeResolver;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SlingFetcherResolverWrapperTest {
+
+    @Mock
+    private SlingDataFetcherSelector dataFetcherSelector;
+
+    @Mock
+    private SlingTypeResolverSelector typeResolverSelector;
+
+    @Mock
+    private Resource resource;
+
+    @Test
+    public void dataFetcher_missingResourceThrows() throws Exception {
+        DataFetchingEnvironment env = mock(DataFetchingEnvironment.class);
+        when(env.getGraphQlContext()).thenReturn(GraphQLContext.newContext().build());
+
+        SlingDataFetcherWrapper<Object> wrapper =
+                new SlingDataFetcherWrapper<>(dataFetcherSelector, "test/fetcher", null, null);
+        try {
+            wrapper.get(env);
+            fail("Expected SlingGraphQLException");
+        } catch (SlingGraphQLException e) {
+            assertTrue(e.getMessage().contains("missing the request Resource"));
+        }
+    }
+
+    @Test
+    public void dataFetcher_missingServiceReturnsNull() throws Exception {
+        DataFetchingEnvironment env = mock(DataFetchingEnvironment.class);
+        when(env.getGraphQlContext())
+                .thenReturn(
+                        GraphQLContext.newContext().of(Resource.class, resource).build());
+        when(dataFetcherSelector.getSlingFetcher("test/fetcher")).thenReturn(null);
+
+        SlingDataFetcherWrapper<Object> wrapper =
+                new SlingDataFetcherWrapper<>(dataFetcherSelector, "test/fetcher", "opts", "src");
+        assertNull(wrapper.get(env));
+    }
+
+    @Test
+    public void dataFetcher_delegatesToLiveService() throws Exception {
+        DataFetchingEnvironment env = mock(DataFetchingEnvironment.class);
+        when(env.getGraphQlContext())
+                .thenReturn(
+                        GraphQLContext.newContext().of(Resource.class, resource).build());
+        @SuppressWarnings("unchecked")
+        SlingDataFetcher<Object> fetcher = mock(SlingDataFetcher.class);
+        when(dataFetcherSelector.getSlingFetcher("test/fetcher")).thenReturn(fetcher);
+        when(fetcher.get(any())).thenReturn("ok");
+
+        SlingDataFetcherWrapper<Object> wrapper =
+                new SlingDataFetcherWrapper<>(dataFetcherSelector, "test/fetcher", "opts", "src");
+        assertSame("ok", wrapper.get(env));
+        verify(fetcher).get(any());
+    }
+
+    @Test
+    public void typeResolver_missingResourceThrows() {
+        TypeResolutionEnvironment env = mock(TypeResolutionEnvironment.class);
+        when(env.getGraphQLContext()).thenReturn(GraphQLContext.newContext().build());
+
+        SlingTypeResolverWrapper wrapper =
+                new SlingTypeResolverWrapper(typeResolverSelector, "test/resolver", null, null);
+        try {
+            wrapper.getType(env);
+            fail("Expected SlingGraphQLException");
+        } catch (SlingGraphQLException e) {
+            assertTrue(e.getMessage().contains("missing the request Resource"));
+        }
+    }
+
+    @Test
+    public void typeResolver_missingServiceReturnsNull() {
+        TypeResolutionEnvironment env = mock(TypeResolutionEnvironment.class);
+        when(env.getGraphQLContext())
+                .thenReturn(
+                        GraphQLContext.newContext().of(Resource.class, resource).build());
+        when(typeResolverSelector.getSlingTypeResolver("test/resolver")).thenReturn(null);
+
+        SlingTypeResolverWrapper wrapper =
+                new SlingTypeResolverWrapper(typeResolverSelector, "test/resolver", "opts", "src");
+        assertNull(wrapper.getType(env));
+    }
+
+    @Test
+    public void typeResolver_delegatesWhenResultIsObjectType() {
+        TypeResolutionEnvironment env = mock(TypeResolutionEnvironment.class);
+        when(env.getGraphQLContext())
+                .thenReturn(
+                        GraphQLContext.newContext().of(Resource.class, resource).build());
+        @SuppressWarnings("unchecked")
+        SlingTypeResolver<Object> resolver = mock(SlingTypeResolver.class);
+        GraphQLObjectType objectType = mock(GraphQLObjectType.class);
+        when(typeResolverSelector.getSlingTypeResolver("test/resolver")).thenReturn(resolver);
+        when(resolver.getType(any())).thenReturn(objectType);
+
+        SlingTypeResolverWrapper wrapper =
+                new SlingTypeResolverWrapper(typeResolverSelector, "test/resolver", "opts", "src");
+        assertSame(objectType, wrapper.getType(env));
+        verify(resolver).getType(any());
+    }
+
+    @Test
+    public void typeResolver_nonObjectTypeResultReturnsNull() {
+        TypeResolutionEnvironment env = mock(TypeResolutionEnvironment.class);
+        when(env.getGraphQLContext())
+                .thenReturn(
+                        GraphQLContext.newContext().of(Resource.class, resource).build());
+        @SuppressWarnings("unchecked")
+        SlingTypeResolver<Object> resolver = mock(SlingTypeResolver.class);
+        when(typeResolverSelector.getSlingTypeResolver(eq("test/resolver"))).thenReturn(resolver);
+        when(resolver.getType(any())).thenReturn("not-a-graphql-object-type");
+
+        SlingTypeResolverWrapper wrapper =
+                new SlingTypeResolverWrapper(typeResolverSelector, "test/resolver", null, null);
+        assertNull(wrapper.getType(env));
+    }
+}

--- a/src/test/java/org/apache/sling/graphql/core/engine/SlingFetcherResolverWrapperTest.java
+++ b/src/test/java/org/apache/sling/graphql/core/engine/SlingFetcherResolverWrapperTest.java
@@ -36,7 +36,6 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -152,7 +151,7 @@ public class SlingFetcherResolverWrapperTest {
                         GraphQLContext.newContext().of(Resource.class, resource).build());
         @SuppressWarnings("unchecked")
         SlingTypeResolver<Object> resolver = mock(SlingTypeResolver.class);
-        when(typeResolverSelector.getSlingTypeResolver(eq("test/resolver"))).thenReturn(resolver);
+        when(typeResolverSelector.getSlingTypeResolver("test/resolver")).thenReturn(resolver);
         when(resolver.getType(any())).thenReturn("not-a-graphql-object-type");
 
         SlingTypeResolverWrapper wrapper =


### PR DESCRIPTION
…yExecutor

Avoid rebuilding makeExecutableSchema on every request under load. Move request Resource into GraphQLContext, look up fetchers/resolvers at request time, and cache GraphQLSchema by SDL hash with per-key single-flight. Enable via executableSchemaCacheEnabled (default false).

